### PR TITLE
Improve Metaculus API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+.mypy_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .vscode/
 .mypy_cache/
+.venv/
+ergo.egg-info/
+*__pycache__*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Ergo
 
 A Python library for forecasting models
+
+

--- a/README.md
+++ b/README.md
@@ -16,3 +16,13 @@ A Python library for forecasting models
         1. Note that if you make changes to the library and need to reload it into the Colab, you'll need to first go to `Runtime > Factory reset runtime` in the Colab (`Restart runtime` will not cause the Colab to reload the library from Github)
     3. Run the Colab, make sure it works. Make sure not to submit any predictions on our main account, use our test credentials if necessary: uname: `oughttest`, pwd: `6vCo39Mz^rrb`
 
+## TODO
+### testing priorities
+1. Metaculus API:
+    1. end-to-end:
+        1. submit_from_samples
+            1. I'd quite like to test this -- I've had this silently fail before, but haven't added a test yet because it would be difficult to
+        1. get_predicted_questions
+        2. show_prediction_results (once we refactor this to produce a dataframe)
+2. 
+

--- a/README.md
+++ b/README.md
@@ -2,4 +2,7 @@
 
 A Python library for forecasting models
 
-
+## Working on this repo
+1. Format code according to [PEP8](https://www.python.org/dev/peps/pep-0008/). I use autopep8 (via VS Code)
+2. Run mypy on code: `mypy .`. There should be 0 errors or warnings, you should get `Success: no issues found`
+3. Test the code: `pytest`. All tests should pass.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Python library for forecasting models
 ## Before submitting a PR
 1. Format code according to [PEP8](https://www.python.org/dev/peps/pep-0008/). I use autopep8 (via the Python VSCode extension)
 2. Run mypy: `mypy .`. There should be 0 errors or warnings, you should get `Success: no issues found`
-3. Run tests: `pytest`. All tests should pass.
+3. Run tests: `pytest -s`. All tests should pass.
 3. Increment the version of this package in:
     1. `pyproject.toml`
     2. `ergo/__init__.py`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 
 A Python library for forecasting models
 
-## Working on this repo
-1. Format code according to [PEP8](https://www.python.org/dev/peps/pep-0008/). I use autopep8 (via VS Code)
-2. Run mypy on code: `mypy .`. There should be 0 errors or warnings, you should get `Success: no issues found`
-3. Test the code: `pytest`. All tests should pass.
+## Before submitting a PR
+1. Format code according to [PEP8](https://www.python.org/dev/peps/pep-0008/). I use autopep8 (via the Python VSCode extension)
+2. Run mypy: `mypy .`. There should be 0 errors or warnings, you should get `Success: no issues found`
+3. Run tests: `pytest`. All tests should pass.
+3. Increment the version of this package in:
+    1. `pyproject.toml`
+    2. `ergo/__init__.py`
+    3. in tests as needed
+4. Make sure the code works with our most recent Colabs:
+    1. Push the code to a branch on Github
+    2. Install the code in the colab like 
+

--- a/README.md
+++ b/README.md
@@ -12,5 +12,6 @@ A Python library for forecasting models
     3. in tests as needed
 4. Make sure the code works with our most recent Colabs:
     1. Push the code to a branch on Github
-    2. Install the code in the colab like 
+    2. Install the code in the Colab like `!pip install --quiet git+https://github.com/oughtinc/ergo.git@branch-name`
+    3. Run the Colab, make sure it works. Make sure not to submit any predictions on our main account, use our test credentials if necessary: uname: `oughttest`, pwd: `6vCo39Mz^rrb`
 

--- a/README.md
+++ b/README.md
@@ -13,5 +13,6 @@ A Python library for forecasting models
 4. Make sure the code works with our most recent Colabs:
     1. Push the code to a branch on Github
     2. Install the code in the Colab like `!pip install --quiet git+https://github.com/oughtinc/ergo.git@branch-name`
+        1. Note that if you make changes to the library and need to reload it into the Colab, you'll need to first go to `Runtime > Factory reset runtime` in the Colab (`Restart runtime` will not cause the Colab to reload the library from Github)
     3. Run the Colab, make sure it works. Make sure not to submit any predictions on our main account, use our test credentials if necessary: uname: `oughttest`, pwd: `6vCo39Mz^rrb`
 

--- a/ergo/__init__.py
+++ b/ergo/__init__.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.0'
- 
+__version__ = '0.2.0'
+
 import ergo.data
 import ergo.metaculus
 import ergo.ppl

--- a/ergo/data/covid19.py
+++ b/ergo/data/covid19.py
@@ -5,82 +5,85 @@ import pandas as pd
 
 class DataLoader:
 
-  def __init__(self):
-    self._warnings = set()
-    self.data = {}
-    self.load()
-  
-  def warn(self, warning):
-    if not warning in self._warnings:
-      print(f"WARNING: {warning}")
-    self._warnings.add(warning)
+    def __init__(self):
+        self._warnings = set()
+        self.data = {}
+        self.load()
 
-  def get(self, name):
-    return self.data[name]
+    def warn(self, warning):
+        if not warning in self._warnings:
+            print(f"WARNING: {warning}")
+        self._warnings.add(warning)
 
-  def load(self):
-    pass
+    def get(self, name):
+        return self.data[name]
 
-  def raw(self):
-    return self.data
-  
-  def __call__(self, *args, **kwargs):
-    return self.get(*args, **kwargs)
+    def load(self):
+        pass
+
+    def raw(self):
+        return self.data
+
+    def __call__(self, *args, **kwargs):
+        return self.get(*args, **kwargs)
 
 
 class WHORegionData(DataLoader):
-  url = "https://gist.githubusercontent.com/brachbach/de74ec9fdee315234976084599a9539c/raw/5e12ee7ba283dc0f11d162893984c620b6d9f703/who_regions.csv"
+    url = "https://gist.githubusercontent.com/brachbach/de74ec9fdee315234976084599a9539c/raw/5e12ee7ba283dc0f11d162893984c620b6d9f703/who_regions.csv"
 
-  def load(self):
-    data = pd.read_csv(self.url)
-    standard_countries = country_converter.convert(names = data["Country"].tolist(), to='name_short')
-    data['standard_country'] = standard_countries 
-    self.data = data
+    def load(self):
+        data = pd.read_csv(self.url)
+        standard_countries = country_converter.convert(
+            names=data["Country"].tolist(), to='name_short')
+        data['standard_country'] = standard_countries
+        self.data = data
 
 
 class HopkinsData(DataLoader):
-  url = "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-Confirmed.csv"
+    url = "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_19-covid-Confirmed.csv"
 
-  def load(self):
-    data = pd.read_csv(self.url)
-    standard_countries = country_converter.convert(names = data["Country/Region"].tolist(), to='name_short')
-    data['standard_country'] = standard_countries
-    self.data = data
+    def load(self):
+        data = pd.read_csv(self.url)
+        standard_countries = country_converter.convert(
+            names=data["Country/Region"].tolist(), to='name_short')
+        data['standard_country'] = standard_countries
+        self.data = data
 
 
 class ConfirmedInfections(DataLoader):
-  def load(self):
-    self.who_regions = WHORegionData().raw()
-    self.hopkins_data = HopkinsData().raw()
-    self.countries = set(self.hopkins_data["standard_country"].tolist())
-    self.regions = set(self.who_regions["Region"].tolist())
+    def load(self):
+        self.who_regions = WHORegionData().raw()
+        self.hopkins_data = HopkinsData().raw()
+        self.countries = set(self.hopkins_data["standard_country"].tolist())
+        self.regions = set(self.who_regions["Region"].tolist())
 
-  def countries_for_region(self, region):
-    return self.who_regions.loc[self.who_regions["Region"] == region, "standard_country"].tolist()
+    def countries_for_region(self, region):
+        return self.who_regions.loc[self.who_regions["Region"] == region, "standard_country"].tolist()
 
-  @functools.lru_cache(None)  
-  def confirmed_for_country(self, country, date, warn=False):
-    country_data = self.hopkins_data.loc[self.hopkins_data["standard_country"] == country][date.format("M/DD/YY")]    
-    if len(country_data) == 0 and warn:
-      self.warn(f"No confirmed case data for country: {country}.")
-    return sum(country_data)
+    @functools.lru_cache(None)
+    def confirmed_for_country(self, country, date, warn=False):
+        country_data = self.hopkins_data.loc[self.hopkins_data["standard_country"] == country][date.format(
+            "M/DD/YY")]
+        if len(country_data) == 0 and warn:
+            self.warn(f"No confirmed case data for country: {country}.")
+        return sum(country_data)
 
-  @functools.lru_cache(None)
-  def confirmed_for_region(self, region, date):
-      countries = self.countries_for_region(region)
-      return sum([self.confirmed_for_country(country, date) for country in countries])
-  
-  def is_country(self, area):
-    return area in self.countries
-  
-  def is_region(self, area):
-    return area in self.regions
+    @functools.lru_cache(None)
+    def confirmed_for_region(self, region, date):
+        countries = self.countries_for_region(region)
+        return sum([self.confirmed_for_country(country, date) for country in countries])
 
-  def get(self, area, date):
-    if self.is_country(area):
-      return self.confirmed_for_country(area, date)
-    elif self.is_region(area):
-      return self.confirmed_for_region(area, date)
-    else:
-      self.warn(f"No confirmed case data for {area}")
-      return 0
+    def is_country(self, area):
+        return area in self.countries
+
+    def is_region(self, area):
+        return area in self.regions
+
+    def get(self, area, date):
+        if self.is_country(area):
+            return self.confirmed_for_country(area, date)
+        elif self.is_region(area):
+            return self.confirmed_for_region(area, date)
+        else:
+            self.warn(f"No confirmed case data for {area}")
+            return 0

--- a/ergo/metaculus.py
+++ b/ergo/metaculus.py
@@ -8,194 +8,278 @@ import numpy as np
 from typing import Optional, List
 
 
-class Metaculus:
-
-  def __init__(self, username, password):
-    self.sessionid = None
-    self.csrftoken = None
-    self.login(username, password)
-  
-  def login(self, username, password):
-    loginURL = "https://www.metaculus.com/api2/accounts/login/"
-    r = requests.post(loginURL, 
-                      data=json.dumps({"username": username, "password": password}), 
-                      headers= { "Content-Type": "application/json" })
-    cookie = r.headers['Set-Cookie']
-    sessionid = None
-    csrftoken = None
-    for s in cookie.split(";"):
-      s = s.strip()
-      if "=" in s:
-        k, v = s.split("=")
-        if k == "Secure, sessionid":
-          sessionid = v
-        elif k == "csrftoken":
-          csrftoken = v
-    
-    self.sessionid = sessionid
-    self.csrftoken = csrftoken
-
-  def get_question(self, question_id: int, name=None):
-    return MetaculusQuestion(question_id, metaculus=self, name=name)
-
-
 class MetaculusQuestion:
-  """
-  Attributes:
-  - url
-  - page_url
-  - id
-  - author
-  - title
-  - status
-  - resolution
-  - created_time
-  - publish_time
-  - close_time
-  - resolve_time
-  - possibilities
-  - can_use_powers
-  - last_activity_time
-  - activity
-  - comment_count
-  - votes
-  - prediction_timeseries
-  - author_name
-  - prediction_histogram
-  - anon_prediction_count        
-  """
-  id: int
-  data: Optional[object]
-  metaculus: Metaculus
-  varname: Optional[str]
+    """
+    Attributes:
+    - url
+    - page_url
+    - id
+    - author
+    - title
+    - status
+    - resolution
+    - created_time
+    - publish_time
+    - close_time
+    - resolve_time
+    - possibilities
+    - can_use_powers
+    - last_activity_time
+    - activity
+    - comment_count
+    - votes
+    - prediction_timeseries
+    - author_name
+    - prediction_histogram
+    - anon_prediction_count        
+    """
+    id: int
+    data: Optional[object]
+    metaculus: Metaculus
+    varname: Optional[str]
 
-  def __init__(self, id: int, metaculus: Metaculus, name=None):
-    self.id = id
-    self.data = None
-    self.metaculus = metaculus
-    self.name = name
-    self.fetch()
-  
-  def api_url(self):
-    return f"https://www.metaculus.com/api2/questions/{self.id}/"
-  
-  def fetch(self):
-    self.data = requests.get(self.api_url()).json()
-    return self.data
+    def __init__(self, id: int, metaculus: Metaculus, name=None):
+        self.id = id
+        self.data = None
+        self.metaculus = metaculus
+        self.name = name
+        self.fetch()
 
-  @property
-  def is_continuous(self):
-    return self.type == "continuous"
-  
-  @property
-  def type(self):
-    return self.possibilities["type"]
-  
-  @property
-  def min(self):
-    if self.is_continuous:
-      return self.possibilities["scale"]["min"]
-    return None
-  
-  @property
-  def max(self):
-    if self.is_continuous:
-      return self.possibilities["scale"]["max"]
-    return None
-  
-  @property
-  def deriv_ratio(self):
-    if self.is_continuous:
-      return self.possibilities["scale"]["deriv_ratio"]
-    return None
+    def api_url(self):
+        return f"https://www.metaculus.com/api2/questions/{self.id}/"
 
-  @property
-  def is_log(self):
-    if self.is_continuous:
-      return self.deriv_ratio != 1
-    return False
-    
-  def __getattr__(self, name):
-    if name in self.data:
-      if name.endswith("_time"):
-        return pendulum.parse(self.data[name]) # TZ
-      return self.data[name]
-    else:
-      raise AttributeError(name)
-  
-  def __str__(self):
-    if self.data:
-      return self.data["title"]
-    return "<MetaculusQuestion>"
-  
-  def submit_from_samples(self, samples, show=False):
-    try:
-      normalized_samples = self.normalize_samples(samples)
-      loc, scale = self.fit_single_logistic(normalized_samples)
-    except FloatingPointError:
-      print("Error on " + question.area)
-      traceback.print_exc()
-    else:
-      self.submit(loc, scale)
-      return (loc, scale)
-  
-  def submit(self, loc, scale):
-    if not self.is_continuous:
-      raise NotImplementedError("Can only submit continuous questions!")
-    if not self.metaculus:
-      raise ValueError("Question was created without Metaculus connection!")
+    def fetch(self):
+        self.data = requests.get(self.api_url()).json()
+        return self.data
 
-    scale = min(max(scale, 0.02), 10)
-    loc = min(max(loc, 0), 1)
-    distribution = scipy.stats.logistic(loc, scale)
-    
-    low = max(distribution.cdf(0), 0.01)
-    high = min(distribution.cdf(1), 0.99)
-    prediction_data = {
-        "prediction":
-        {
-          "kind":"multi",
-          "d":[
-              {
-                  "kind":"logistic","x0":loc,"s":scale,"w":1,"low":low,"high":high
-              }
-          ]
-        }
-        ,
-        "void":False
-      }
-    requests.post(
-        f"""https://www.metaculus.com/api2/questions/{self.id}/predict/""", 
-        headers={
-            "Cookie": f"csrftoken={self.metaculus.csrftoken}; sessionid={self.metaculus.sessionid}", 
-            "Content-Type": "application/json",
-            "Referer": "https://www.metaculus.com/",
-            "X-CSRFToken": self.metaculus.csrftoken
+    @property
+    def is_continuous(self):
+        return self.type == "continuous"
+
+    @property
+    def type(self):
+        return self.possibilities["type"]
+
+    @property
+    def min(self):
+        if self.is_continuous:
+            return self.possibilities["scale"]["min"]
+        return None
+
+    @property
+    def max(self):
+        if self.is_continuous:
+            return self.possibilities["scale"]["max"]
+        return None
+
+    @property
+    def deriv_ratio(self):
+        if self.is_continuous:
+            return self.possibilities["scale"]["deriv_ratio"]
+        return None
+
+    @property
+    def is_log(self):
+        if self.is_continuous:
+            return self.deriv_ratio != 1
+        return False
+
+    def __getattr__(self, name):
+        if name in self.data:
+            if name.endswith("_time"):
+                return pendulum.parse(self.data[name])  # TZ
+            return self.data[name]
+        else:
+            raise AttributeError(name)
+
+    def __str__(self):
+        if self.data:
+            return self.data["title"]
+        return "<MetaculusQuestion>"
+
+    def get_submission(self, samples):
+        try:
+            normalized_samples = self.normalize_samples(samples)
+            loc, scale = self.fit_single_logistic(normalized_samples)
+        except FloatingPointError:
+            print("Error on " + question.area)
+            traceback.print_exc()
+        else:
+            return {
+                "normalized_samples": normalized_samples,
+                "loc": loc,
+                "scale": scale
+            }
+
+    def submit_from_samples(self, samples):
+        submission = self.get_submission(samples)
+        self.submit(submission["loc"], submission["scale"])
+
+    def show_submission(self, samples):
+        pyplot.figure()
+        submission = self.get_submission(samples)
+        rv = scipy.stats.logistic(submission["loc"], submission["scale"])
+        x = np.linspace(0, 1, 200)
+        pyplot.plot(x, rv.pdf(x))
+        sns.distplot(
+            np.array(submission["normalized_samples"]), label="samples")
+        sns.distplot(np.array(rv.rvs(1000)), label="prediction")
+        pyplot.legend()
+        pyplot.show()
+
+    def submit(self, loc, scale):
+        if not self.is_continuous:
+            raise NotImplementedError("Can only submit continuous questions!")
+        if not self.metaculus:
+            raise ValueError(
+                "Question was created without Metaculus connection!")
+
+        scale = min(max(scale, 0.02), 10)
+        loc = min(max(loc, 0), 1)
+        distribution = scipy.stats.logistic(loc, scale)
+
+        low = max(distribution.cdf(0), 0.01)
+        high = min(distribution.cdf(1), 0.99)
+        prediction_data = {
+            "prediction":
+            {
+                "kind": "multi",
+                "d": [
+                    {
+                        "kind": "logistic", "x0": loc, "s": scale, "w": 1, "low": low, "high": high
+                    }
+                ]
             },
-        data=json.dumps(prediction_data)
-      )
-  
-  def normalize_samples(self, samples, epsilon=1e-9):
-    if self.is_continuous:
-      if self.is_log:
-        samples = np.maximum(samples, epsilon)
-        samples = samples / self.min
-        samples = np.log(samples) / np.log(self.deriv_ratio)
-      else:
-        samples = (samples - self.min) / (self.max - self.min)
-    return samples
+            "void": False
+        }
+        requests.post(
+            f"""https://www.metaculus.com/api2/questions/{self.id}/predict/""",
+            # headers={
+            #     "Cookie": f"csrftoken={self.metaculus.csrftoken}; sessionid={self.metaculus.sessionid}",
+            #     "Content-Type": "application/json",
+            #     "Referer": "https://www.metaculus.com/",
+            #     "X-CSRFToken": self.metaculus.csrftoken
+            # },
+            data=json.dumps(prediction_data)
+        )
 
-  def fit_single_logistic(self, samples):
-    with np.errstate(all='raise'):
-      loc, scale = scipy.stats.logistic.fit(samples)
-      scale = min(max(scale, 0.02), 10)
-      loc = min(max(loc, -0.1565), 1.1565)
-      return loc, scale
+    def normalize_samples(self, samples, epsilon=1e-9):
+        if self.is_continuous:
+            if self.is_log:
+                samples = np.maximum(samples, epsilon)
+                samples = samples / self.min
+                samples = np.log(samples) / np.log(self.deriv_ratio)
+            else:
+                samples = (samples - self.min) / (self.max - self.min)
+        return samples
 
-  @classmethod
-  def to_dataframe(self, questions: List["MetaculusQuestion"]):
-    columns = ["id", "name", "title", "resolve_time"]
-    data = []
-    for question in questions:
-      data.append([question.id, question.name, question.title, question.resolve_time])
-    return pd.DataFrame(data, columns=columns)
+    def fit_single_logistic(self, samples):
+        with np.errstate(all='raise'):
+            loc, scale = scipy.stats.logistic.fit(samples)
+            scale = min(max(scale, 0.02), 10)
+            loc = min(max(loc, -0.1565), 1.1565)
+            return loc, scale
+
+    @classmethod
+    def to_dataframe(self, questions: List["MetaculusQuestion"]):
+        columns = ["id", "name", "title", "resolve_time"]
+        data = []
+        for question in questions:
+            data.append([question.id, question.name,
+                         question.title, question.resolve_time])
+        return pd.DataFrame(data, columns=columns)
+
+
+class Metaculus:
+    api_url = "https://www.metaculus.com/api2"
+
+    def __init__(self, username, password):
+        self.user_id = None
+        self.s = requests.Session()
+        self.login(username, password)
+
+    def login(self, username, password):
+        loginURL = f"{self.api_url}/accounts/login/"
+        r = self.s.post(loginURL,
+                        data=json.dumps(
+                            {"username": username, "password": password}))
+
+        self.user_id = r.json()['user_id']
+
+    def get_question(self, id: int, varname=None):
+        r = self.s.get(f"{self.api_url}/questions/{id}")
+        data = r.json()
+        # pp.pprint(data)
+        if(data["possibilities"]["type"] == "binary"):
+            return BinaryQuestion(id, self, data, varname)
+        if(data["possibilities"]["type"] == "continuous"):
+            return ContinuousQuestion(id, self, data, varname)
+        raise NotImplementedError(
+            "We couldn't determine whether this question was binary, continuous, or something else")
+
+    def get_predicted_questions(self):
+        r = self.s.get(f"{self.api_url}/questions/?guessed_by={self.user_id}")
+        json_data = r.json()
+        # pp.pprint(json_data)
+        results = json_data["results"]
+        question_ids = [result["id"] for result in results]
+        return [self.get_question(id) for id in question_ids]
+        # TODO: retrieve additional data if next link is not None
+        # print(results)
+
+    def show_prediction_results(self):
+        questions = self.get_predicted_questions()
+        binary_questions = [
+            question for question in questions if isinstance(question, BinaryQuestion)]
+        continuous_questions = [
+            question for question in questions if not isinstance(question, BinaryQuestion)]
+        binary_scores = [question.score_prediction()
+                         for question in binary_questions]
+        continuous_scores = [question.score_prediction()
+                             for question in continuous_questions]
+        mean_binary_score = np.mean(binary_scores)
+        mean_continuous_score = np.mean(continuous_scores)
+
+        s = mean_binary_score
+        p = (1 + np.sqrt(1-4*s))/2
+
+        display(HTML(f"""<div>
+        <strong>Summary</strong>
+        <ol>
+            <li>Mean Binary Score (lower is better): {mean_binary_score:.2}
+            <ul>
+                <li>Interpretation 1: we make calibrated forecasts of probability p={p:.2} (these predictions resolve true {p * 100:.0}% of the time)</li>
+            </ul>
+            </li>
+            <li>Mean Continuous Score (higher is better): {mean_continuous_score:.2}</li>
+        </ol>
+        <br />
+        </div>"""))
+
+        for idx, question in enumerate(questions):
+            resolution = question.data["resolution"]
+            expected_resolution, score = question.score_prediction()
+
+            display(HTML(f"""<div>
+                <strong>{idx+1} - {question.data["title"]}</strong>
+                <ol>
+                    <li><em><a target="_blank" href="http://metaculus.com{question.data["page_url"]}">Metaculus link</a></em></li>
+                    <li><em>open date</em>: {parse(question.data["publish_time"]).strftime("%b %d, %Y")}</li>
+                    <li><em>resolve date</em>: {parse(question.data["resolve_time"]).strftime("%b %d, %Y")}</li>
+                    <li><em>type</em>: {question.data["possibilities"]["type"]}</li>
+                    <li><em>resolution</em>: {resolution}</li>"""))
+
+            if isinstance(question, BinaryQuestion):
+                if resolution is None:
+                    display(HTML(
+                        '<li><em>community expected resolution</em>: {:.2f}</li>'.format(expected_resolution)))
+                    display(
+                        HTML('<li><em>brier score (lower is better)</em>: {:.3f}</li>'.format(score)))
+            else:
+                if resolution is None:
+                    display(HTML(
+                        '<li><em>community expected resolution</em>: {:.2f}</li>'.format(expected_resolution)))
+                    display(
+                        HTML('<li><em>log pdf score (higher is better)</em>: {:.3f}</li>'.format(score)))
+                display(HTML(f"""</ol>
+                <br />"""))

--- a/ergo/metaculus.py
+++ b/ergo/metaculus.py
@@ -36,7 +36,7 @@ class MetaculusQuestion:
     id: int
     data: Optional[object]
     metaculus: "Metaculus"
-    varname: Optional[str]
+    name: Optional[str]
 
     def __init__(self, id: int, metaculus: "Metaculus", data, name=None):
         self.id = id
@@ -227,36 +227,29 @@ class Metaculus:
     def login(self, username, password):
         loginURL = f"{self.api_url}/accounts/login/"
         r = self.s.post(loginURL,
-                        headers={
-                            "Content-Type": "application/json",
-                        },
-                        data=json.dumps(
-                            {"username": username, "password": password}))
-
-        print(r.json())
+                        headers={"Content-Type": "application/json", },
+                        data=json.dumps({"username": username, "password": password}))
 
         self.user_id = r.json()['user_id']
 
-    def get_question(self, id: int, varname=None):
+    def get_question(self, id: int, name=None):
         r = self.s.get(f"{self.api_url}/questions/{id}")
         data = r.json()
         # pp.pprint(data)
         if(data["possibilities"]["type"] == "binary"):
-            return BinaryQuestion(id, self, data, varname)
+            return BinaryQuestion(id, self, data, name)
         if(data["possibilities"]["type"] == "continuous"):
-            return ContinuousQuestion(id, self, data, varname)
+            return ContinuousQuestion(id, self, data, name)
         raise NotImplementedError(
             "We couldn't determine whether this question was binary, continuous, or something else")
 
     def get_predicted_questions(self):
         r = self.s.get(f"{self.api_url}/questions/?guessed_by={self.user_id}")
         json_data = r.json()
-        # pp.pprint(json_data)
         results = json_data["results"]
         question_ids = [result["id"] for result in results]
         return [self.get_question(id) for id in question_ids]
         # TODO: retrieve additional data if next link is not None
-        # print(results)
 
     def show_prediction_results(self):
         questions = self.get_predicted_questions()

--- a/ergo/metaculus.py
+++ b/ergo/metaculus.py
@@ -154,12 +154,9 @@ class MetaculusQuestion:
         }
         requests.post(
             f"""https://www.metaculus.com/api2/questions/{self.id}/predict/""",
-            # headers={
-            #     "Cookie": f"csrftoken={self.metaculus.csrftoken}; sessionid={self.metaculus.sessionid}",
-            #     "Content-Type": "application/json",
-            #     "Referer": "https://www.metaculus.com/",
-            #     "X-CSRFToken": self.metaculus.csrftoken
-            # },
+            headers={
+                "Content-Type": "application/json",
+            },
             data=json.dumps(prediction_data)
         )
 
@@ -230,8 +227,13 @@ class Metaculus:
     def login(self, username, password):
         loginURL = f"{self.api_url}/accounts/login/"
         r = self.s.post(loginURL,
+                        headers={
+                            "Content-Type": "application/json",
+                        },
                         data=json.dumps(
                             {"username": username, "password": password}))
+
+        print(r.json())
 
         self.user_id = r.json()['user_id']
 

--- a/ergo/metaculus.py
+++ b/ergo/metaculus.py
@@ -117,7 +117,7 @@ class MetaculusQuestion:
     def submit_from_samples(self, samples):
         submission = self.get_submission(samples)
         self.submit(submission["loc"], submission["scale"])
-        return (loc, scale)
+        return (submission["loc"], submission["scale"])
 
     def show_submission(self, samples):
         pyplot.figure()

--- a/poetry.lock
+++ b/poetry.lock
@@ -58,6 +58,17 @@ version = "0.6.7"
 pandas = ">=0.17.0"
 
 [[package]]
+category = "main"
+description = "Composable style cycles"
+name = "cycler"
+optional = false
+python-versions = "*"
+version = "0.10.0"
+
+[package.dependencies]
+six = "*"
+
+[[package]]
 category = "dev"
 description = "Type stubs for Python machine learning libraries"
 name = "data-science-types"
@@ -99,6 +110,32 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx", "rst.linker"]
 testing = ["packaging", "importlib-resources"]
+
+[[package]]
+category = "main"
+description = "A fast implementation of the Cassowary constraint solver"
+name = "kiwisolver"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.1.0"
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
+category = "main"
+description = "Python plotting package"
+name = "matplotlib"
+optional = false
+python-versions = ">=3.6"
+version = "3.2.1"
+
+[package.dependencies]
+cycler = ">=0.10"
+kiwisolver = ">=1.0.1"
+numpy = ">=1.11"
+pyparsing = ">=2.0.1,<2.0.4 || >2.0.4,<2.1.2 || >2.1.2,<2.1.6 || >2.1.6"
+python-dateutil = ">=2.1"
 
 [[package]]
 category = "dev"
@@ -220,7 +257,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.8.1"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python parsing module"
 name = "pyparsing"
 optional = false
@@ -418,7 +455,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "e4f2d16f4ed719db422bbbb60f5e1a1be0bcaaecc542a96515f84ac80864cb63"
+content-hash = "0a05054d0a31f9ce3b59be6d8c757efd8469258cbba8becbe6fecdadcbd80d4c"
 python-versions = "3.6.9"
 
 [metadata.files]
@@ -445,6 +482,10 @@ colorama = [
 country-converter = [
     {file = "country_converter-0.6.7.tar.gz", hash = "sha256:bc01ba2592b77a78b4f3e6f76600ca27852d71d1512cf1f320fecbcaaea3c6f9"},
 ]
+cycler = [
+    {file = "cycler-0.10.0-py2.py3-none-any.whl", hash = "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d"},
+    {file = "cycler-0.10.0.tar.gz", hash = "sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"},
+]
 data-science-types = [
     {file = "data-science-types-0.2.6.tar.gz", hash = "sha256:e16e6452c3bfecc45089c654831c23da4b701730552e4e588940f0c696f092d6"},
     {file = "data_science_types-0.2.6-py3-none-any.whl", hash = "sha256:6397df3250e0eaf597a16f77cd614031ddc713dd53cf250f804d0a9c15452702"},
@@ -460,6 +501,61 @@ idna = [
 importlib-metadata = [
     {file = "importlib_metadata-1.5.0-py2.py3-none-any.whl", hash = "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"},
     {file = "importlib_metadata-1.5.0.tar.gz", hash = "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302"},
+]
+kiwisolver = [
+    {file = "kiwisolver-1.1.0-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:7f4dd50874177d2bb060d74769210f3bce1af87a8c7cf5b37d032ebf94f0aca3"},
+    {file = "kiwisolver-1.1.0-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:fe51b79da0062f8e9d49ed0182a626a7dc7a0cbca0328f612c6ee5e4711c81e4"},
+    {file = "kiwisolver-1.1.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:f790f8b3dff3d53453de6a7b7ddd173d2e020fb160baff578d578065b108a05f"},
+    {file = "kiwisolver-1.1.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:f2b22153870ca5cf2ab9c940d7bc38e8e9089fa0f7e5856ea195e1cf4ff43d5a"},
+    {file = "kiwisolver-1.1.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:e8bf074363ce2babeb4764d94f8e65efd22e6a7c74860a4f05a6947afc020ff2"},
+    {file = "kiwisolver-1.1.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:05b5b061e09f60f56244adc885c4a7867da25ca387376b02c1efc29cc16bcd0f"},
+    {file = "kiwisolver-1.1.0-cp27-none-win32.whl", hash = "sha256:47b8cb81a7d18dbaf4fed6a61c3cecdb5adec7b4ac292bddb0d016d57e8507d5"},
+    {file = "kiwisolver-1.1.0-cp27-none-win_amd64.whl", hash = "sha256:b64916959e4ae0ac78af7c3e8cef4becee0c0e9694ad477b4c6b3a536de6a544"},
+    {file = "kiwisolver-1.1.0-cp34-cp34m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:682e54f0ce8f45981878756d7203fd01e188cc6c8b2c5e2cf03675390b4534d5"},
+    {file = "kiwisolver-1.1.0-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:d52e3b1868a4e8fd18b5cb15055c76820df514e26aa84cc02f593d99fef6707f"},
+    {file = "kiwisolver-1.1.0-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:8aa7009437640beb2768bfd06da049bad0df85f47ff18426261acecd1cf00897"},
+    {file = "kiwisolver-1.1.0-cp34-none-win32.whl", hash = "sha256:26f4fbd6f5e1dabff70a9ba0d2c4bd30761086454aa30dddc5b52764ee4852b7"},
+    {file = "kiwisolver-1.1.0-cp34-none-win_amd64.whl", hash = "sha256:79bfb2f0bd7cbf9ea256612c9523367e5ec51d7cd616ae20ca2c90f575d839a2"},
+    {file = "kiwisolver-1.1.0-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:3b2378ad387f49cbb328205bda569b9f87288d6bc1bf4cd683c34523a2341efe"},
+    {file = "kiwisolver-1.1.0-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:aa716b9122307c50686356cfb47bfbc66541868078d0c801341df31dca1232a9"},
+    {file = "kiwisolver-1.1.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:58e626e1f7dfbb620d08d457325a4cdac65d1809680009f46bf41eaf74ad0187"},
+    {file = "kiwisolver-1.1.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:e3a21a720791712ed721c7b95d433e036134de6f18c77dbe96119eaf7aa08004"},
+    {file = "kiwisolver-1.1.0-cp35-none-win32.whl", hash = "sha256:939f36f21a8c571686eb491acfffa9c7f1ac345087281b412d63ea39ca14ec4a"},
+    {file = "kiwisolver-1.1.0-cp35-none-win_amd64.whl", hash = "sha256:9733b7f64bd9f807832d673355f79703f81f0b3e52bfce420fc00d8cb28c6a6c"},
+    {file = "kiwisolver-1.1.0-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:acc4df99308111585121db217681f1ce0eecb48d3a828a2f9bbf9773f4937e9e"},
+    {file = "kiwisolver-1.1.0-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:9105ce82dcc32c73eb53a04c869b6a4bc756b43e4385f76ea7943e827f529e4d"},
+    {file = "kiwisolver-1.1.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:f16814a4a96dc04bf1da7d53ee8d5b1d6decfc1a92a63349bb15d37b6a263dd9"},
+    {file = "kiwisolver-1.1.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:400599c0fe58d21522cae0e8b22318e09d9729451b17ee61ba8e1e7c0346565c"},
+    {file = "kiwisolver-1.1.0-cp36-none-win32.whl", hash = "sha256:db1a5d3cc4ae943d674718d6c47d2d82488ddd94b93b9e12d24aabdbfe48caee"},
+    {file = "kiwisolver-1.1.0-cp36-none-win_amd64.whl", hash = "sha256:5a52e1b006bfa5be04fe4debbcdd2688432a9af4b207a3f429c74ad625022641"},
+    {file = "kiwisolver-1.1.0-cp37-cp37m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:a02f6c3e229d0b7220bd74600e9351e18bc0c361b05f29adae0d10599ae0e326"},
+    {file = "kiwisolver-1.1.0-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:9491578147849b93e70d7c1d23cb1229458f71fc79c51d52dce0809b2ca44eea"},
+    {file = "kiwisolver-1.1.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:5c7ca4e449ac9f99b3b9d4693debb1d6d237d1542dd6a56b3305fe8a9620f883"},
+    {file = "kiwisolver-1.1.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a0c0a9f06872330d0dd31b45607197caab3c22777600e88031bfe66799e70bb0"},
+    {file = "kiwisolver-1.1.0-cp37-none-win32.whl", hash = "sha256:8944a16020c07b682df861207b7e0efcd2f46c7488619cb55f65882279119389"},
+    {file = "kiwisolver-1.1.0-cp37-none-win_amd64.whl", hash = "sha256:d3fcf0819dc3fea58be1fd1ca390851bdb719a549850e708ed858503ff25d995"},
+    {file = "kiwisolver-1.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:933df612c453928f1c6faa9236161a1d999a26cd40abf1dc5d7ebbc6dbfb8fca"},
+    {file = "kiwisolver-1.1.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:d22702cadb86b6fcba0e6b907d9f84a312db9cd6934ee728144ce3018e715ee1"},
+    {file = "kiwisolver-1.1.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:210d8c39d01758d76c2b9a693567e1657ec661229bc32eac30761fa79b2474b0"},
+    {file = "kiwisolver-1.1.0-cp38-none-win32.whl", hash = "sha256:76275ee077772c8dde04fb6c5bc24b91af1bb3e7f4816fd1852f1495a64dad93"},
+    {file = "kiwisolver-1.1.0-cp38-none-win_amd64.whl", hash = "sha256:3b15d56a9cd40c52d7ab763ff0bc700edbb4e1a298dc43715ecccd605002cf11"},
+    {file = "kiwisolver-1.1.0.tar.gz", hash = "sha256:53eaed412477c836e1b9522c19858a8557d6e595077830146182225613b11a75"},
+]
+matplotlib = [
+    {file = "matplotlib-3.2.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e06304686209331f99640642dee08781a9d55c6e32abb45ed54f021f46ccae47"},
+    {file = "matplotlib-3.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ce378047902b7a05546b6485b14df77b2ff207a0054e60c10b5680132090c8ee"},
+    {file = "matplotlib-3.2.1-cp36-cp36m-win32.whl", hash = "sha256:2466d4dddeb0f5666fd1e6736cc5287a4f9f7ae6c1a9e0779deff798b28e1d35"},
+    {file = "matplotlib-3.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:f4412241e32d0f8d3713b68d3ca6430190a5e8a7c070f1c07d7833d8c5264398"},
+    {file = "matplotlib-3.2.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e20ba7fb37d4647ac38f3c6d8672dd8b62451ee16173a0711b37ba0ce42bf37d"},
+    {file = "matplotlib-3.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:282b3fc8023c4365bad924d1bb442ddc565c2d1635f210b700722776da466ca3"},
+    {file = "matplotlib-3.2.1-cp37-cp37m-win32.whl", hash = "sha256:c1cf735970b7cd424502719b44288b21089863aaaab099f55e0283a721aaf781"},
+    {file = "matplotlib-3.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:56d3147714da5c7ac4bc452d041e70e0e0b07c763f604110bd4e2527f320b86d"},
+    {file = "matplotlib-3.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:af14e77829c5b5d5be11858d042d6f2459878f8e296228c7ea13ec1fd308eb68"},
+    {file = "matplotlib-3.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:aae7d107dc37b4bb72dcc45f70394e6df2e5e92ac4079761aacd0e2ad1d3b1f7"},
+    {file = "matplotlib-3.2.1-cp38-cp38-win32.whl", hash = "sha256:d35891a86a4388b6965c2d527b9a9f9e657d9e110b0575ca8a24ba0d4e34b8fc"},
+    {file = "matplotlib-3.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:4bb50ee4755271a2017b070984bcb788d483a8ce3132fab68393d1555b62d4ba"},
+    {file = "matplotlib-3.2.1-pp373-pypy36_pp73-win32.whl", hash = "sha256:7a9baefad265907c6f0b037c8c35a10cf437f7708c27415a5513cf09ac6d6ddd"},
+    {file = "matplotlib-3.2.1.tar.gz", hash = "sha256:ffe2f9cdcea1086fc414e82f42271ecf1976700b8edd16ca9d376189c6d93aee"},
 ]
 more-itertools = [
     {file = "more-itertools-8.2.0.tar.gz", hash = "sha256:b1ddb932186d8a6ac451e1d95844b382f55e12686d51ca0c68b6f61f2ab7a507"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ scipy = "^1.4.1"
 pyro-ppl = "^1.3.0"
 pandas = "0.25.0"
 pendulum = "^2.1.0"
+matplotlib = "^3.2.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ergo"
-version = "0.1.0"
+version = "0.2.0"
 description = ""
 authors = ["Ought <team@ought.org>"]
 

--- a/tests/test_ergo.py
+++ b/tests/test_ergo.py
@@ -2,4 +2,4 @@ from ergo import __version__
 
 
 def test_version():
-    assert __version__ == '0.1.0'
+    assert __version__ == '0.2.0'

--- a/tests/test_ergo.py
+++ b/tests/test_ergo.py
@@ -1,5 +1,14 @@
-from ergo import __version__
+import ergo
+
+test_uname = "oughttest"
+test_pwd = "6vCo39Mz^rrb"
+test_user_id = 112420
 
 
 def test_version():
-    assert __version__ == '0.2.0'
+    assert ergo.__version__ == '0.2.0'
+
+
+def test_login():
+    metaculus = ergo.Metaculus(test_uname, test_pwd)
+    assert metaculus.user_id == test_user_id

--- a/tests/test_ergo.py
+++ b/tests/test_ergo.py
@@ -12,3 +12,12 @@ def test_version():
 def test_login():
     metaculus = ergo.Metaculus(test_uname, test_pwd)
     assert metaculus.user_id == test_user_id
+
+
+def test_submission():
+    metaculus = ergo.Metaculus(test_uname, test_pwd)
+
+    # need to replace this with a different question once this one resolves on Mar 27
+    euro_question = metaculus.get_question(3706)
+    r = euro_question.submit(0.534894790856232, 0.02)
+    assert r.status_code == 202


### PR DESCRIPTION
1. Make it easy to see what predictions you're planning to submit before you submit them via `show_submission`
2. Retrieve and display your prediction results so far via `show_prediction_results`
3. Add some tests so that you can figure out whether the API is working without firing up a Colab

Also, some housekeeping:
1. add to the README re: developing on this project
2. run autopep8 formatter on everything

Compatible with the Colab v6, as shown by: https://colab.research.google.com/drive/1xfhW9kKbr-0dkquzjWGD_OHyPHlKQMAA?hl=en#scrollTo=u5-EaP2LUfBG

The API improvements are pretty rough still, but I thought it was best to at least make a PR for them (and the housekeeping stuff) so we're all working off of the same code

Things I'd like to improve about the API improvements
1. display prediction results in a dataframe, not HTML
2. add a method to show questions eligible for forecasting in a dataframe
3. small bug fixes
4. probably move some functionality out of here and into a Colab
5. general code cleanup -- look over the code more carefully and fix anything that seems off

These are coming soon, should be by EOD

I'd guess we should go ahead and merge my current code and then have me do another PR for these fixes, but will leave that up to @stuhlmueller 