### PR TITLE
Format all the files using black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
 
 script:
 - poetry run mypy .
+- poetry run flake8
 - poetry run black . --check
 - poetry run python -m pytest --cov=ergo -s .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 
 script:
 - poetry run mypy .
-- poetry run flake8
+- poetry run black . --check
 - poetry run python -m pytest --cov=ergo -s .
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ This way, you can quickly make changes to ergo and see them reflected in your Co
 If you get an error in the Colab, try following the instructions provided in the error. If that doesn't work, try the [official instructions for connecting to a local runtime](https://research.google.com/colaboratory/local-runtimes.html).
 
 ### Before submitting a PR
-1. Format code according to [PEP8](https://www.python.org/dev/peps/pep-0008/). You could use autopep8.
+1. Format code using [black](https://github.com/psf/black).
+    * Follow [these instructions](https://code.visualstudio.com/docs/python/editing#_formatting) to set `black` as your formatter in VSCode.
 2. Run mypy: `mypy .`. There should be 0 errors or warnings, you should get `Success: no issues found`
 3. Run tests: `pytest -s`. All tests should pass.

--- a/README.md
+++ b/README.md
@@ -167,5 +167,7 @@ If you get an error in the Colab, try following the instructions provided in the
 ### Before submitting a PR
 1. Format code using [black](https://github.com/psf/black).
     * Follow [these instructions](https://code.visualstudio.com/docs/python/editing#_formatting) to set `black` as your formatter in VSCode.
-2. Run mypy: `mypy .`. There should be 0 errors or warnings, you should get `Success: no issues found`
-3. Run tests: `pytest -s`. All tests should pass.
+2. Lint code using [flake8](https://flake8.pycqa.org/en/latest/).
+    * Follow [these instructions](https://code.visualstudio.com/docs/python/linting#_specific-linters) to use flake8 in VSCode
+3. Run mypy: `mypy .`. There should be 0 errors or warnings, you should get `Success: no issues found`
+4. Run tests: `pytest -s`. All tests should pass.

--- a/ergo/data/covid19.py
+++ b/ergo/data/covid19.py
@@ -4,7 +4,6 @@ import pandas as pd
 
 
 class DataLoader:
-
     def __init__(self):
         self._warnings = set()
         self.data = {}
@@ -29,27 +28,33 @@ class DataLoader:
 
 
 class WHORegionData(DataLoader):
-    url = ("https://gist.githubusercontent.com/brachbach/de74ec9fdee315234976084599a9539c"
-           "/raw/5e12ee7ba283dc0f11d162893984c620b6d9f703/who_regions.csv")
+    url = (
+        "https://gist.githubusercontent.com/brachbach/de74ec9fdee315234976084599a9539c"
+        "/raw/5e12ee7ba283dc0f11d162893984c620b6d9f703/who_regions.csv"
+    )
 
     def load(self):
         data = pd.read_csv(self.url)
         standard_countries = country_converter.convert(
-            names=data["Country"].tolist(), to='name_short')
-        data['standard_country'] = standard_countries
+            names=data["Country"].tolist(), to="name_short"
+        )
+        data["standard_country"] = standard_countries
         self.data = data
 
 
 class HopkinsData(DataLoader):
-    url = ("https://raw.githubusercontent.com/CSSEGISandData/COVID-19/"
-           "master/csse_covid_19_data/csse_covid_19_time_series/"
-           "time_series_covid19_confirmed_global.csv")
+    url = (
+        "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/"
+        "master/csse_covid_19_data/csse_covid_19_time_series/"
+        "time_series_covid19_confirmed_global.csv"
+    )
 
     def load(self):
         data = pd.read_csv(self.url)
         standard_countries = country_converter.convert(
-            names=data["Country/Region"].tolist(), to='name_short')
-        data['standard_country'] = standard_countries
+            names=data["Country/Region"].tolist(), to="name_short"
+        )
+        data["standard_country"] = standard_countries
         self.data = data
 
 
@@ -61,12 +66,15 @@ class ConfirmedInfections(DataLoader):
         self.regions = set(self.who_regions["Region"].tolist())
 
     def countries_for_region(self, region):
-        return self.who_regions.loc[self.who_regions["Region"] == region, "standard_country"].tolist()
+        return self.who_regions.loc[
+            self.who_regions["Region"] == region, "standard_country"
+        ].tolist()
 
     @functools.lru_cache(None)
     def confirmed_for_country(self, country, date, warn=False):
-        country_data = self.hopkins_data.loc[self.hopkins_data["standard_country"] == country][date.format(
-            "M/D/YY")]
+        country_data = self.hopkins_data.loc[
+            self.hopkins_data["standard_country"] == country
+        ][date.format("M/D/YY")]
         if len(country_data) == 0 and warn:
             self.warn(f"No confirmed case data for country: {country}.")
         return sum(country_data)

--- a/ergo/logistic.py
+++ b/ergo/logistic.py
@@ -20,19 +20,19 @@ from typing import List
 
 
 @dataclass
-class LogisticParams():
+class LogisticParams:
     loc: float
     scale: float
 
 
 @dataclass
-class LogisticMixtureParams():
+class LogisticMixtureParams:
     components: List[LogisticParams]
     probs: List[float]
 
 
 def fit_single_scipy(samples) -> LogisticParams:
-    with onp.errstate(all='raise'):  # type: ignore
+    with onp.errstate(all="raise"):  # type: ignore
         loc, scale = oscipy.stats.logistic.fit(samples)
         return LogisticParams(loc, scale)
 
@@ -47,15 +47,12 @@ def logistic_logpdf(x, loc, scale) -> DeviceArray:
 @jit
 def mixture_logpdf_single(datum, components):
     component_scores = []
-    unnormalized_weights = np.array(
-        [component[2] for component in components])
+    unnormalized_weights = np.array([component[2] for component in components])
     weights = nn.log_softmax(unnormalized_weights)
     for component, weight in zip(components, weights):
         loc = component[0]
-        scale = np.max([component[1], 0.01])   # Find a better solution?
-        component_scores.append(
-            logistic_logpdf(
-                datum, loc, scale) + weight)
+        scale = np.max([component[1], 0.01])  # Find a better solution?
+        component_scores.append(logistic_logpdf(datum, loc, scale) + weight)
     return scipy.special.logsumexp(np.array(component_scores))
 
 
@@ -73,7 +70,7 @@ def initialize_components(num_components):
     # Weights sum to 1 (are given in log space)
     # We use onp to initialize parameters since we don't want to track
     # randomness
-    components = onp.random.rand(num_components, 3) * 0.1 + 1.
+    components = onp.random.rand(num_components, 3) * 0.1 + 1.0
     components[:, 2] = -num_components
     return components
 
@@ -82,13 +79,14 @@ def structure_mixture_params(components) -> LogisticMixtureParams:
     unnormalized_weights = components[:, 2]
     probs = list(np.exp(nn.log_softmax(unnormalized_weights)))
     component_params = [
-        LogisticParams(
-            component[0],
-            component[1]) for component in components]
+        LogisticParams(component[0], component[1]) for component in components
+    ]
     return LogisticMixtureParams(components=component_params, probs=probs)
 
 
-def fit_mixture(data, num_components=3, verbose=False, num_samples=5000) -> LogisticMixtureParams:
+def fit_mixture(
+    data, num_components=3, verbose=False, num_samples=5000
+) -> LogisticMixtureParams:
     # the data might be something weird, like a pandas dataframe column;
     # turn it into a regular old numpy array
     data_as_np_array = np.array(data)
@@ -127,7 +125,7 @@ def sample_mixture(mixture_params):
 def plot_mixture(params: LogisticMixtureParams, data=None):
     learned_samples = np.array([sample_mixture(params) for _ in range(5000)])
     ax = seaborn.distplot(learned_samples, label="Mixture")
-    ax.set(xlabel='Sample value', ylabel='Density')
+    ax.set(xlabel="Sample value", ylabel="Density")
     if data is not None:
         seaborn.distplot(data, label="Data")
     pyplot.legend()  # type: ignore

--- a/ergo/metaculus.py
+++ b/ergo/metaculus.py
@@ -106,8 +106,7 @@ class MetaculusQuestion:
             ]
         else:
             columns = ["id", "title", "resolve_time"]
-            data = [
-                [question.id, question.title, question.resolve_time]
+            data = [[question.id, question.title, question.resolve_time]
                 for question in questions
             ]
         return pd.DataFrame(data, columns=columns)

--- a/ergo/metaculus.py
+++ b/ergo/metaculus.py
@@ -106,7 +106,8 @@ class MetaculusQuestion:
             ]
         else:
             columns = ["id", "title", "resolve_time"]
-            data = [[question.id, question.title, question.resolve_time]
+            data = [
+                [question.id, question.title, question.resolve_time]
                 for question in questions
             ]
         return pd.DataFrame(data, columns=columns)

--- a/ergo/metaculus.py
+++ b/ergo/metaculus.py
@@ -54,6 +54,7 @@ class MetaculusQuestion:
     - prediction_histogram
     - anon_prediction_count
     """
+
     id: int
     data: Optional[object]
     metaculus: "Metaculus"
@@ -91,8 +92,7 @@ class MetaculusQuestion:
         return "<MetaculusQuestion>"
 
     def refresh_question(self):
-        r = self.metaculus.s.get(
-            f"{self.metaculus.api_url}/questions/{self.id}")
+        r = self.metaculus.s.get(f"{self.metaculus.api_url}/questions/{self.id}")
         self.data = r.json()
 
     @staticmethod
@@ -100,12 +100,16 @@ class MetaculusQuestion:
         show_names = any(q.name for q in questions)
         if show_names:
             columns = ["id", "name", "title", "resolve_time"]
-            data = [[question.id, question.name,
-                     question.title, question.resolve_time] for question in questions]
+            data = [
+                [question.id, question.name, question.title, question.resolve_time]
+                for question in questions
+            ]
         else:
             columns = ["id", "title", "resolve_time"]
-            data = [[question.id, question.title, question.resolve_time]
-                    for question in questions]
+            data = [
+                [question.id, question.title, question.resolve_time]
+                for question in questions
+            ]
         return pd.DataFrame(data, columns=columns)
 
     def sample_community(self):
@@ -116,8 +120,10 @@ class BinaryQuestion(MetaculusQuestion):
     def score_prediction(self, prediction, resolution) -> ScoredPrediction:
         predicted = prediction["x"]
         # Brier score, see https://en.wikipedia.org/wiki/Brier_score#Definition. 0 is best, 1 is worst, 0.25 is chance
-        score = (resolution - predicted)**2
-        return ScoredPrediction(prediction["t"], prediction, resolution, score, self.__str__())
+        score = (resolution - predicted) ** 2
+        return ScoredPrediction(
+            prediction["t"], prediction, resolution, score, self.__str__()
+        )
 
     def get_scored_predictions(self):
         resolution = self.resolution
@@ -125,15 +131,14 @@ class BinaryQuestion(MetaculusQuestion):
             last_community_prediction = self.prediction_timeseries[-1]
             resolution = last_community_prediction["distribution"]["avg"]
         predictions = self.my_predictions["predictions"]
-        return [self.score_prediction(prediction, resolution) for prediction in predictions]
+        return [
+            self.score_prediction(prediction, resolution) for prediction in predictions
+        ]
 
     def submit(self, p: float):
         return self.metaculus.post(
             f"{self.metaculus.api_url}/questions/{self.id}/predict/",
-            {
-                "prediction": p,
-                "void": False
-            }
+            {"prediction": p, "void": False},
         )
 
 
@@ -171,9 +176,10 @@ class ContinuousQuestion(MetaculusQuestion):
         TODO: maybe it's better to fit the logistic first then normalize, rather than the other way around?"""
         raise NotImplementedError("This should be implemented by a subclass")
 
-    def get_submission_params(self, logistic_params: logistic.LogisticParams) -> SubmissionLogisticParams:
-        distribution = stats.logistic(
-            logistic_params.loc, logistic_params.scale)
+    def get_submission_params(
+        self, logistic_params: logistic.LogisticParams
+    ) -> SubmissionLogisticParams:
+        distribution = stats.logistic(logistic_params.loc, logistic_params.scale)
         # The loc and scale have to be within a certain range for the Metaculus API to accept the prediction.
 
         # max loc of 3 set based on API response to prediction on
@@ -208,8 +214,7 @@ class ContinuousQuestion(MetaculusQuestion):
             min_open_high = low + 0.01
 
             max_open_high = 0.99
-            high = max(min(distribution.cdf(1), max_open_high),
-                       min_open_high)
+            high = max(min(distribution.cdf(1), max_open_high), min_open_high)
         else:
             high = 1
 
@@ -234,10 +239,10 @@ class ContinuousQuestion(MetaculusQuestion):
         outside_range_scale = 0.02
 
         sample_below_range = -abs(np.random.logistic(0, outside_range_scale))
-        sample_above_range = abs(np.random.logistic(
-            1, outside_range_scale))
-        sample_in_range = ppl.sample(self.community_dist_in_range(
-        )) / float(len(self.prediction_histogram))
+        sample_above_range = abs(np.random.logistic(1, outside_range_scale))
+        sample_in_range = ppl.sample(self.community_dist_in_range()) / float(
+            len(self.prediction_histogram)
+        )
 
         p_below = self.latest_community_prediction["low"]
         p_above = 1 - self.latest_community_prediction["high"]
@@ -245,30 +250,39 @@ class ContinuousQuestion(MetaculusQuestion):
 
         return ppl.random_choice(
             [sample_below_range, sample_in_range, sample_above_range],
-            ps=[p_below, p_in_range, p_above])
+            ps=[p_below, p_in_range, p_above],
+        )
 
     def sample_community(self):
         normalized_sample = self.sample_normalized_community()
-        sample = torch.Tensor(
-            self.denormalize_samples([normalized_sample]))
+        sample = torch.Tensor(self.denormalize_samples([normalized_sample]))
         if self.name:
             ppl.tag(sample, self.name)
         return sample
 
-    def get_submission(self, mixture_params: logistic.LogisticMixtureParams) -> SubmissionMixtureParams:
-        submission_logistic_params = [self.get_submission_params(
-            logistic_params) for logistic_params in mixture_params.components]
+    def get_submission(
+        self, mixture_params: logistic.LogisticMixtureParams
+    ) -> SubmissionMixtureParams:
+        submission_logistic_params = [
+            self.get_submission_params(logistic_params)
+            for logistic_params in mixture_params.components
+        ]
 
         return SubmissionMixtureParams(submission_logistic_params, mixture_params.probs)
 
-    def get_submission_from_samples(self, samples, samples_for_fit=5000) -> SubmissionMixtureParams:
+    def get_submission_from_samples(
+        self, samples, samples_for_fit=5000
+    ) -> SubmissionMixtureParams:
         normalized_samples = self.normalize_samples(samples)
         mixture_params = logistic.fit_mixture(
-            normalized_samples, num_samples=samples_for_fit)
+            normalized_samples, num_samples=samples_for_fit
+        )
         return self.get_submission(mixture_params)
 
     @staticmethod
-    def format_logistic_for_api(submission: SubmissionLogisticParams, weight: float) -> dict:
+    def format_logistic_for_api(
+        submission: SubmissionLogisticParams, weight: float
+    ) -> dict:
         # convert all the numbers to floats here so that you can be sure that wherever they originated
         # (e.g. numpy), they'll be regular old floats that can be converted to json by json.dumps
         return {
@@ -277,23 +291,24 @@ class ContinuousQuestion(MetaculusQuestion):
             "s": float(submission.scale),
             "w": float(weight),
             "low": float(submission.low),
-            "high": float(submission.high)
+            "high": float(submission.high),
         }
 
     def submit(self, submission: SubmissionMixtureParams) -> requests.Response:
         prediction_data = {
-            "prediction":
-            {
+            "prediction": {
                 "kind": "multi",
-                "d": [self.format_logistic_for_api(logistic_params, submission.probs[idx])
-                      for idx, logistic_params in enumerate(submission.components)]
+                "d": [
+                    self.format_logistic_for_api(logistic_params, submission.probs[idx])
+                    for idx, logistic_params in enumerate(submission.components)
+                ],
             },
-            "void": False
+            "void": False,
         }
 
         r = self.metaculus.post(
             f"""{self.metaculus.api_url}/questions/{self.id}/predict/""",
-            prediction_data
+            prediction_data,
         )
 
         self.refresh_question()
@@ -306,14 +321,19 @@ class ContinuousQuestion(MetaculusQuestion):
 
     @staticmethod
     def get_logistic_from_json(logistic_json: Dict) -> SubmissionLogisticParams:
-        return SubmissionLogisticParams(logistic_json["x0"],
-                                        logistic_json["s"], logistic_json["low"],
-                                        logistic_json["high"])
+        return SubmissionLogisticParams(
+            logistic_json["x0"],
+            logistic_json["s"],
+            logistic_json["low"],
+            logistic_json["high"],
+        )
 
     @classmethod
     def get_submission_from_json(cls, submission_json: Dict) -> SubmissionMixtureParams:
-        components = [cls.get_logistic_from_json(
-            logistic_json) for logistic_json in submission_json]
+        components = [
+            cls.get_logistic_from_json(logistic_json)
+            for logistic_json in submission_json
+        ]
         probs = [logistic_json["w"] for logistic_json in submission_json]
         return SubmissionMixtureParams(components, probs)
 
@@ -345,33 +365,43 @@ class LinearQuestion(ContinuousQuestion):
         samples = np.array(samples)
         return self.question_range["min"] + (self.question_range_width) * samples
 
-    def get_true_scale_logistic_params(self,
-                                       submission_logistic_params: SubmissionLogisticParams) -> logistic.LogisticParams:
+    def get_true_scale_logistic_params(
+        self, submission_logistic_params: SubmissionLogisticParams
+    ) -> logistic.LogisticParams:
         """Get the logistic on the actual scale of the question,
         from the normalized logistic used in the submission
         TODO: also return low and high on the true scale"""
 
-        true_loc = submission_logistic_params.loc * \
-            self.question_range_width + self.question_range["min"]
+        true_loc = (
+            submission_logistic_params.loc * self.question_range_width
+            + self.question_range["min"]
+        )
 
         true_scale = submission_logistic_params.scale * self.question_range_width
 
         return logistic.LogisticParams(true_loc, true_scale)
 
-    def get_true_scale_mixture(self, submission_params: SubmissionMixtureParams) -> logistic.LogisticMixtureParams:
-        true_scale_logistics_params = [self.get_true_scale_logistic_params(
-            submission_logistic_params) for submission_logistic_params in submission_params.components]
+    def get_true_scale_mixture(
+        self, submission_params: SubmissionMixtureParams
+    ) -> logistic.LogisticMixtureParams:
+        true_scale_logistics_params = [
+            self.get_true_scale_logistic_params(submission_logistic_params)
+            for submission_logistic_params in submission_params.components
+        ]
 
         return logistic.LogisticMixtureParams(
-            true_scale_logistics_params, submission_params.probs)
+            true_scale_logistics_params, submission_params.probs
+        )
 
     def show_prediction(self, prediction: SubmissionMixtureParams, samples=None):
         true_scale_prediction = self.get_true_scale_mixture(prediction)
 
         pyplot.figure()
         pyplot.title(f"{self} prediction", y=1.07)  # type: ignore
-        logistic.plot_mixture(true_scale_prediction,  # type: ignore
-                              data=samples)  # type: ignore
+        logistic.plot_mixture(
+            true_scale_prediction,  # type: ignore
+            data=samples,
+        )  # type: ignore
 
     def show_submission(self, samples):
         submission = self.get_submission_from_samples(samples)
@@ -385,8 +415,7 @@ class LinearQuestion(ContinuousQuestion):
 
         community_samples = [self.sample_community() for _ in range(0, 1000)]
 
-        ax = seaborn.distplot(
-            community_samples, label="Community")
+        ax = seaborn.distplot(community_samples, label="Community")
 
         pyplot.legend()
 
@@ -410,8 +439,7 @@ class LogQuestion(ContinuousQuestion):
         return math.log(floored_timber, self.deriv_ratio)
 
     def true_from_normalized_value(self, normalized_value):
-        deriv_term = (self.deriv_ratio ** normalized_value - 1) / \
-            (self.deriv_ratio - 1)
+        deriv_term = (self.deriv_ratio ** normalized_value - 1) / (self.deriv_ratio - 1)
         scaled = self.question_range_width * deriv_term
         return self.question_range["min"] + scaled
 
@@ -424,21 +452,25 @@ class LogQuestion(ContinuousQuestion):
     @staticmethod
     def set_true_x_ticks():
         true_tick_values = [
-            f"{np.exp(log_tick):.1e}" for log_tick in pyplot.xticks()[0]]
+            f"{np.exp(log_tick):.1e}" for log_tick in pyplot.xticks()[0]
+        ]
 
-        pyplot.xticks(pyplot.xticks()[0],
-                      true_tick_values, rotation="vertical")
+        pyplot.xticks(pyplot.xticks()[0], true_tick_values, rotation="vertical")
 
     def plot_log_prediction(self, prediction: SubmissionMixtureParams, samples=None):
-        prediction_normed_samples = np.array([logistic.sample_mixture(
-            prediction) for _ in range(0, 5000)])
+        prediction_normed_samples = np.array(
+            [logistic.sample_mixture(prediction) for _ in range(0, 5000)]
+        )
 
-        prediction_true_scale_samples = np.array([self.true_from_normalized_value(
-            submission_sample) for submission_sample in prediction_normed_samples])
+        prediction_true_scale_samples = np.array(
+            [
+                self.true_from_normalized_value(submission_sample)
+                for submission_sample in prediction_normed_samples
+            ]
+        )
 
-        ax = seaborn.distplot(
-            np.log(prediction_true_scale_samples), label="Mixture")
-        ax.set(xlabel='Sample value', ylabel='Density')
+        ax = seaborn.distplot(np.log(prediction_true_scale_samples), label="Mixture")
+        ax.set(xlabel="Sample value", ylabel="Density")
 
         if samples is not None:
             seaborn.distplot(np.log(samples), label="Data")
@@ -446,11 +478,9 @@ class LogQuestion(ContinuousQuestion):
         pyplot.legend()  # type: ignore
 
     def plot_log_community_prediction(self):
-        community_samples = np.log([self.sample_community()
-                                    for _ in range(0, 1000)])
+        community_samples = np.log([self.sample_community() for _ in range(0, 1000)])
 
-        ax = seaborn.distplot(
-            community_samples, label="Community")
+        ax = seaborn.distplot(community_samples, label="Community")
 
         pyplot.legend()
 
@@ -468,7 +498,9 @@ class LogQuestion(ContinuousQuestion):
         self.set_true_x_ticks()
         pyplot.show()
 
-    def show_prediction(self, prediction: SubmissionMixtureParams, samples=None, show_community=False):
+    def show_prediction(
+        self, prediction: SubmissionMixtureParams, samples=None, show_community=False
+    ):
         pyplot.figure()
         pyplot.title(f"{self} prediction", y=1.07)  # type: ignore
         self.plot_log_prediction(prediction, samples)
@@ -496,11 +528,13 @@ class Metaculus:
 
     def login(self, username, password):
         loginURL = f"{self.api_url}/accounts/login/"
-        r = self.s.post(loginURL,
-                        headers={"Content-Type": "application/json", },
-                        data=json.dumps({"username": username, "password": password}))
+        r = self.s.post(
+            loginURL,
+            headers={"Content-Type": "application/json",},
+            data=json.dumps({"username": username, "password": password}),
+        )
 
-        self.user_id = r.json()['user_id']
+        self.user_id = r.json()["user_id"]
 
     def post(self, url: str, data: Dict):
         r = self.s.post(
@@ -508,67 +542,78 @@ class Metaculus:
             headers={
                 "Content-Type": "application/json",
                 "Referer": self.api_url,
-                "X-CSRFToken": self.s.cookies.get_dict()["csrftoken"]
+                "X-CSRFToken": self.s.cookies.get_dict()["csrftoken"],
             },
-            data=json.dumps(data)
+            data=json.dumps(data),
         )
         try:
             r.raise_for_status()
 
         except requests.exceptions.HTTPError as e:
-            e.args = (str(
-                e.args), f"request body: {e.request.body}", f"response json: {e.response.json()}")
+            e.args = (
+                str(e.args),
+                f"request body: {e.request.body}",
+                f"response json: {e.response.json()}",
+            )
             raise
 
         return r
 
     def make_question_from_data(self, data=Dict, name=None) -> MetaculusQuestion:
-        if(data["possibilities"]["type"] == "binary"):
+        if data["possibilities"]["type"] == "binary":
             return BinaryQuestion(data["id"], self, data, name)
-        if(data["possibilities"]["type"] == "continuous"):
-            if(data["possibilities"]["scale"]["deriv_ratio"] != 1):
+        if data["possibilities"]["type"] == "continuous":
+            if data["possibilities"]["scale"]["deriv_ratio"] != 1:
                 return LogQuestion(data["id"], self, data, name)
             return LinearQuestion(data["id"], self, data, name)
         raise NotImplementedError(
-            "We couldn't determine whether this question was binary, continuous, or something else")
+            "We couldn't determine whether this question was binary, continuous, or something else"
+        )
 
     def get_question(self, id: int, name=None) -> MetaculusQuestion:
         r = self.s.get(f"{self.api_url}/questions/{id}")
         data = r.json()
         return self.make_question_from_data(data, name)
 
-    def get_questions_json(self,
-                           question_status: Literal["all",
-                                                    "upcoming", "open", "closed", "resolved",
-                                                    "discussion"] = "all",
-                           player_status: Literal["any", "predicted",
-                                                  "not-predicted", "author", "interested",
-                                                  "private"] = "any",  # 20 results per page
-                           pages: int = 1, ) -> List[Dict]:
+    def get_questions_json(
+        self,
+        question_status: Literal[
+            "all", "upcoming", "open", "closed", "resolved", "discussion"
+        ] = "all",
+        player_status: Literal[
+            "any", "predicted", "not-predicted", "author", "interested", "private"
+        ] = "any",  # 20 results per page
+        pages: int = 1,
+    ) -> List[Dict]:
         query_params = [f"status={question_status}", "order_by=-publish_time"]
         if player_status != "any":
             if player_status == "private":
                 query_params.append("access=private")
             else:
                 query_params.append(
-                    f"{self.player_status_to_api_wording[player_status]}={self.user_id}")
+                    f"{self.player_status_to_api_wording[player_status]}={self.user_id}"
+                )
 
         query_string = "&".join(query_params)
 
-        def get_questions_for_pages(query_string: str, max_pages: int = 1,
-                                    current_page: int = 1, results=[]) -> List[Dict]:
+        def get_questions_for_pages(
+            query_string: str, max_pages: int = 1, current_page: int = 1, results=[]
+        ) -> List[Dict]:
             if current_page > max_pages:
                 return results
 
             r = self.s.get(
-                f"{self.api_url}/questions/?{query_string}&page={current_page}")
+                f"{self.api_url}/questions/?{query_string}&page={current_page}"
+            )
 
             if r.json() == {"detail": "Invalid page."}:
                 return results
 
             r.raise_for_status()
 
-            return get_questions_for_pages(query_string, max_pages, current_page + 1, results + r.json()["results"])
+            return get_questions_for_pages(
+                query_string, max_pages, current_page + 1, results + r.json()["results"]
+            )
 
         return get_questions_for_pages(query_string, pages)
 
@@ -579,5 +624,6 @@ class Metaculus:
 
         questions_df["i_created"] = questions_df["author"] == self.user_id
         questions_df["i_predicted"] = questions_df["my_predictions"].apply(
-            lambda x: x is not None)
+            lambda x: x is not None
+        )
         return questions_df

--- a/ergo/metaculus.py
+++ b/ergo/metaculus.py
@@ -530,7 +530,7 @@ class Metaculus:
         loginURL = f"{self.api_url}/accounts/login/"
         r = self.s.post(
             loginURL,
-            headers={"Content-Type": "application/json",},
+            headers={"Content-Type": "application/json"},
             data=json.dumps({"username": username, "password": password}),
         )
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -11,6 +11,14 @@ six = "*"
 
 [[package]]
 category = "dev"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+name = "appdirs"
+optional = false
+python-versions = "*"
+version = "1.4.3"
+
+[[package]]
+category = "dev"
 description = "Disable App Nap on OS X 10.9"
 marker = "sys_platform == \"darwin\" or platform_system == \"Darwin\" or python_version >= \"3.3\" and sys_platform == \"darwin\""
 name = "appnope"
@@ -62,6 +70,26 @@ version = "0.1.0"
 
 [[package]]
 category = "dev"
+description = "The uncompromising code formatter."
+name = "black"
+optional = false
+python-versions = ">=3.6"
+version = "19.10b0"
+
+[package.dependencies]
+appdirs = "*"
+attrs = ">=18.1.0"
+click = ">=6.5"
+pathspec = ">=0.6,<1"
+regex = "*"
+toml = ">=0.9.4"
+typed-ast = ">=1.4.0"
+
+[package.extras]
+d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
+
+[[package]]
+category = "dev"
 description = "An easy safelist-based HTML-sanitizing tool."
 name = "bleach"
 optional = false
@@ -87,6 +115,14 @@ name = "chardet"
 optional = false
 python-versions = "*"
 version = "3.0.4"
+
+[[package]]
+category = "dev"
+description = "Composable command line interface toolkit"
+name = "click"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "7.1.1"
 
 [[package]]
 category = "dev"
@@ -664,6 +700,14 @@ version = "0.7.0"
 testing = ["docopt", "pytest (>=3.0.7)"]
 
 [[package]]
+category = "dev"
+description = "Utility library for gitignore style pattern matching of file paths."
+name = "pathspec"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.8.0"
+
+[[package]]
 category = "main"
 description = "Python datetimes made easy"
 name = "pendulum"
@@ -950,6 +994,14 @@ python-versions = "*"
 version = "1.9.0"
 
 [[package]]
+category = "dev"
+description = "Alternative regular expression module, to replace re."
+name = "regex"
+optional = false
+python-versions = "*"
+version = "2020.4.4"
+
+[[package]]
 category = "main"
 description = "Python HTTP for Humans."
 name = "requests"
@@ -1031,6 +1083,14 @@ version = "0.4.4"
 
 [package.extras]
 test = ["pathlib2"]
+
+[[package]]
+category = "dev"
+description = "Python Library for Tom's Obvious, Minimal Language"
+name = "toml"
+optional = false
+python-versions = "*"
+version = "0.10.0"
 
 [[package]]
 category = "main"
@@ -1144,12 +1204,16 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "9b12d4ed19f93490f5aa2ce447b0ba836591ab9ef1ddc0d46301464000f4ebed"
+content-hash = "54a913dfdf031bfc297e19a5dcc037f19081971738eca2d1cb6977eb17d77502"
 python-versions = "3.6.9"
 
 [metadata.files]
 absl-py = [
     {file = "absl-py-0.9.0.tar.gz", hash = "sha256:75e737d6ce7723d9ff9b7aa1ba3233c34be62ef18d5859e706b8fdc828989830"},
+]
+appdirs = [
+    {file = "appdirs-1.4.3-py2.py3-none-any.whl", hash = "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"},
+    {file = "appdirs-1.4.3.tar.gz", hash = "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92"},
 ]
 appnope = [
     {file = "appnope-0.1.0-py2.py3-none-any.whl", hash = "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0"},
@@ -1170,6 +1234,10 @@ backcall = [
     {file = "backcall-0.1.0.tar.gz", hash = "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4"},
     {file = "backcall-0.1.0.zip", hash = "sha256:bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"},
 ]
+black = [
+    {file = "black-19.10b0-py36-none-any.whl", hash = "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b"},
+    {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
+]
 bleach = [
     {file = "bleach-3.1.4-py2.py3-none-any.whl", hash = "sha256:cc8da25076a1fe56c3ac63671e2194458e0c4d9c7becfd52ca251650d517903c"},
     {file = "bleach-3.1.4.tar.gz", hash = "sha256:e78e426105ac07026ba098f04de8abe9b6e3e98b5befbf89b51a5ef0a4292b03"},
@@ -1181,6 +1249,10 @@ certifi = [
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
     {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
+]
+click = [
+    {file = "click-7.1.1-py2.py3-none-any.whl", hash = "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"},
+    {file = "click-7.1.1.tar.gz", hash = "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc"},
 ]
 codecov = [
     {file = "codecov-2.0.22-py2.py3-none-any.whl", hash = "sha256:09fb045eb044a619cd2b9dacd7789ae8e322cb7f18196378579fd8d883e6b665"},
@@ -1364,6 +1436,11 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 matplotlib = [
@@ -1481,6 +1558,10 @@ pandocfilters = [
 parso = [
     {file = "parso-0.7.0-py2.py3-none-any.whl", hash = "sha256:158c140fc04112dc45bca311633ae5033c2c2a7b732fa33d0955bad8152a8dd0"},
     {file = "parso-0.7.0.tar.gz", hash = "sha256:908e9fae2144a076d72ae4e25539143d40b8e3eafbaeae03c1bfe226f4cdf12c"},
+]
+pathspec = [
+    {file = "pathspec-0.8.0-py2.py3-none-any.whl", hash = "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0"},
+    {file = "pathspec-0.8.0.tar.gz", hash = "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"},
 ]
 pendulum = [
     {file = "pendulum-2.1.0-cp27-cp27m-macosx_10_13_x86_64.whl", hash = "sha256:9eda38ff65b1f297d860d3f562480e048673fb4b81fdd5c8c55decb519b97ed2"},
@@ -1641,6 +1722,29 @@ qtpy = [
     {file = "QtPy-1.9.0-py2.py3-none-any.whl", hash = "sha256:fa0b8363b363e89b2a6f49eddc162a04c0699ae95e109a6be3bb145a913190ea"},
     {file = "QtPy-1.9.0.tar.gz", hash = "sha256:2db72c44b55d0fe1407be8fba35c838ad0d6d3bb81f23007886dc1fc0f459c8d"},
 ]
+regex = [
+    {file = "regex-2020.4.4-cp27-cp27m-win32.whl", hash = "sha256:90742c6ff121a9c5b261b9b215cb476eea97df98ea82037ec8ac95d1be7a034f"},
+    {file = "regex-2020.4.4-cp27-cp27m-win_amd64.whl", hash = "sha256:24f4f4062eb16c5bbfff6a22312e8eab92c2c99c51a02e39b4eae54ce8255cd1"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:08119f707f0ebf2da60d2f24c2f39ca616277bb67ef6c92b72cbf90cbe3a556b"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:c9423a150d3a4fc0f3f2aae897a59919acd293f4cb397429b120a5fcd96ea3db"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:c087bff162158536387c53647411db09b6ee3f9603c334c90943e97b1052a156"},
+    {file = "regex-2020.4.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:1cbe0fa0b7f673400eb29e9ef41d4f53638f65f9a2143854de6b1ce2899185c3"},
+    {file = "regex-2020.4.4-cp36-cp36m-win32.whl", hash = "sha256:0ce9537396d8f556bcfc317c65b6a0705320701e5ce511f05fc04421ba05b8a8"},
+    {file = "regex-2020.4.4-cp36-cp36m-win_amd64.whl", hash = "sha256:7e1037073b1b7053ee74c3c6c0ada80f3501ec29d5f46e42669378eae6d4405a"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4385f12aa289d79419fede43f979e372f527892ac44a541b5446617e4406c468"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a58dd45cb865be0ce1d5ecc4cfc85cd8c6867bea66733623e54bd95131f473b6"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:ccccdd84912875e34c5ad2d06e1989d890d43af6c2242c6fcfa51556997af6cd"},
+    {file = "regex-2020.4.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:ea4adf02d23b437684cd388d557bf76e3afa72f7fed5bbc013482cc00c816948"},
+    {file = "regex-2020.4.4-cp37-cp37m-win32.whl", hash = "sha256:2294f8b70e058a2553cd009df003a20802ef75b3c629506be20687df0908177e"},
+    {file = "regex-2020.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:e91ba11da11cf770f389e47c3f5c30473e6d85e06d7fd9dcba0017d2867aab4a"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5635cd1ed0a12b4c42cce18a8d2fb53ff13ff537f09de5fd791e97de27b6400e"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:23069d9c07e115537f37270d1d5faea3e0bdded8279081c4d4d607a2ad393683"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c162a21e0da33eb3d31a3ac17a51db5e634fc347f650d271f0305d96601dc15b"},
+    {file = "regex-2020.4.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:fb95debbd1a824b2c4376932f2216cc186912e389bdb0e27147778cf6acb3f89"},
+    {file = "regex-2020.4.4-cp38-cp38-win32.whl", hash = "sha256:2a3bf8b48f8e37c3a40bb3f854bf0121c194e69a650b209628d951190b862de3"},
+    {file = "regex-2020.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3"},
+    {file = "regex-2020.4.4.tar.gz", hash = "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142"},
+]
 requests = [
     {file = "requests-2.21.0-py2.py3-none-any.whl", hash = "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"},
     {file = "requests-2.21.0.tar.gz", hash = "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e"},
@@ -1687,6 +1791,11 @@ terminado = [
 testpath = [
     {file = "testpath-0.4.4-py2.py3-none-any.whl", hash = "sha256:bfcf9411ef4bf3db7579063e0546938b1edda3d69f4e1fb8756991f5951f85d4"},
     {file = "testpath-0.4.4.tar.gz", hash = "sha256:60e0a3261c149755f4399a1fff7d37523179a70fdc3abdf78de9fc2604aeec7e"},
+]
+toml = [
+    {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},
+    {file = "toml-0.10.0-py2.py3-none-any.whl", hash = "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"},
+    {file = "toml-0.10.0.tar.gz", hash = "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c"},
 ]
 torch = [
     {file = "torch-1.4.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:271d4d1e44df6ed57c530f8849b028447c62b8a19b8e8740dd9baa56e7f682c1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ IPython = "^7.13.0"
 jupyter = "^1.0.0"
 codecov = "^2.0.22"
 flake8 = "^3.7.9"
+black = {version = "^19.10b0", allow-prereleases = true}
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,25 +1,25 @@
 import ergo
 
 mock_true_params = ergo.logistic.LogisticMixtureParams(
-    components=[ergo.logistic.LogisticParams(loc=10000, scale=1000),
-                ergo.logistic.LogisticParams(loc=100000, scale=10000)],
-    probs=[0.8, 0.2]
+    components=[
+        ergo.logistic.LogisticParams(loc=10000, scale=1000),
+        ergo.logistic.LogisticParams(loc=100000, scale=10000),
+    ],
+    probs=[0.8, 0.2],
 )
 
 mock_normalized_params = ergo.logistic.LogisticMixtureParams(
-    components=[ergo.logistic.LogisticParams(loc=0.15, scale=0.037034005),
-                ergo.logistic.LogisticParams(loc=0.85, scale=0.032395907)],
-    probs=[0.6, 0.4]
+    components=[
+        ergo.logistic.LogisticParams(loc=0.15, scale=0.037034005),
+        ergo.logistic.LogisticParams(loc=0.85, scale=0.032395907),
+    ],
+    probs=[0.6, 0.4],
 )
 
 mock_log_question_data = {
     "id": 0,
     "possibilities": {
         "type": "continuous",
-        "scale": {
-            "deriv_ratio": 10,
-            "min": 1,
-            "max": 10
-        }
-    }
+        "scale": {"deriv_ratio": 10, "min": 1, "max": 10},
+    },
 }

--- a/tests/test_ergo.py
+++ b/tests/test_ergo.py
@@ -8,6 +8,7 @@ class TestPPL:
             y = ergo.beta_from_hits(2, 10, name="y")
             z = x * y
             ergo.tag(z, "z")
+
         samples = ergo.run(model, num_samples=1000)
         stats = samples.describe()
         assert 3.5 < stats["x"]["mean"] < 4.5

--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -8,7 +8,7 @@ def f(x, y):
 
 def test_jax():
     gf = jit(grad(f, (0, 1)))
-    grads = gf(1., 1.)
+    grads = gf(1.0, 1.0)
     assert float(grads[0]) == pytest.approx(2.0)
     assert float(grads[1]) == pytest.approx(3.0)
 

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -44,6 +44,7 @@ def test_fit_mixture_large():
     assert scales[0] == pytest.approx(0.1, abs=0.2)
     assert scales[1] == pytest.approx(0.2, abs=0.2)
 
+
 # visual tests, comment out usually
 
 # def test_visual_plot_mixture():

--- a/tests/test_metaculus.py
+++ b/tests/test_metaculus.py
@@ -20,10 +20,15 @@ class TestMetaculus:
     continuous_log_open_question = metaculus.get_question(3961)
     closed_question = metaculus.get_question(3965)
     binary_question = metaculus.get_question(3966)
-    mock_samples = np.array([ergo.logistic.sample_mixture(
-        tests.mocks.mock_true_params) for _ in range(0, 1000)])
+    mock_samples = np.array(
+        [
+            ergo.logistic.sample_mixture(tests.mocks.mock_true_params)
+            for _ in range(0, 1000)
+        ]
+    )
     mock_log_question = metaculus.make_question_from_data(
-        tests.mocks.mock_log_question_data)
+        tests.mocks.mock_log_question_data
+    )
 
     def test_login(self):
         assert self.metaculus.user_id == user_id
@@ -40,25 +45,29 @@ class TestMetaculus:
 
     def test_submit_continuous_linear_open(self):
         submission = self.continuous_linear_open_question.get_submission(
-            tests.mocks.mock_normalized_params)
+            tests.mocks.mock_normalized_params
+        )
         r = self.continuous_linear_open_question.submit(submission)
         assert r.status_code == 202
 
     def test_submit_continuous_linear_closed(self):
         submission = self.continuous_linear_closed_question.get_submission(
-            tests.mocks.mock_normalized_params)
+            tests.mocks.mock_normalized_params
+        )
         r = self.continuous_linear_closed_question.submit(submission)
         assert r.status_code == 202
 
     def test_submit_continuous_log_open(self):
         submission = self.continuous_log_open_question.get_submission(
-            tests.mocks.mock_normalized_params)
+            tests.mocks.mock_normalized_params
+        )
         r = self.continuous_log_open_question.submit(submission)
         assert r.status_code == 202
 
     def test_submit_from_samples(self):
         r = self.continuous_linear_open_question.submit_from_samples(
-            self.mock_samples, samples_for_fit=1000)
+            self.mock_samples, samples_for_fit=1000
+        )
         assert r.status_code == 202
 
     def test_submit_binary(self):
@@ -68,7 +77,8 @@ class TestMetaculus:
     def test_submit_closed_question_fails(self):
         with pytest.raises(requests.exceptions.HTTPError):
             submission = self.closed_question.get_submission(
-                tests.mocks.mock_normalized_params)
+                tests.mocks.mock_normalized_params
+            )
             r = self.closed_question.submit(submission)
             print(r)
 
@@ -85,43 +95,60 @@ class TestMetaculus:
         assert len(two_pages) >= 40
 
     def test_get_questions_player_status(self):
-        qs_i_predicted = self.metaculus.make_questions_df(self.metaculus.get_questions_json(
-            player_status="predicted"))
+        qs_i_predicted = self.metaculus.make_questions_df(
+            self.metaculus.get_questions_json(player_status="predicted")
+        )
         assert qs_i_predicted["i_predicted"].all()
 
-        not_predicted = self.metaculus.make_questions_df(self.metaculus.get_questions_json(
-            player_status="not-predicted"))
+        not_predicted = self.metaculus.make_questions_df(
+            self.metaculus.get_questions_json(player_status="not-predicted")
+        )
         assert (not_predicted["i_predicted"] == False).all()  # noqa: E712
 
     def test_get_questions_question_status(self):
-        open = self.metaculus.make_questions_df(self.metaculus.get_questions_json(
-            question_status="open"))
-        assert(open["close_time"] > pendulum.now()).all()
+        open = self.metaculus.make_questions_df(
+            self.metaculus.get_questions_json(question_status="open")
+        )
+        assert (open["close_time"] > pendulum.now()).all()
 
         closed = self.metaculus.make_questions_df(
-            self.metaculus.get_questions_json(question_status="closed"))
-        assert(closed["close_time"] < pendulum.now()).all()
+            self.metaculus.get_questions_json(question_status="closed")
+        )
+        assert (closed["close_time"] < pendulum.now()).all()
 
     def test_submitted_equals_predicted_linear(self):
         self.continuous_linear_open_question.submit_from_samples(self.mock_samples)
-        latest_prediction = self.continuous_linear_open_question.get_latest_normalized_prediction()
+        latest_prediction = (
+            self.continuous_linear_open_question.get_latest_normalized_prediction()
+        )
         scaled_params = self.continuous_linear_open_question.get_true_scale_mixture(
-            latest_prediction)
-        prediction_samples = np.array([ergo.logistic.sample_mixture(
-            scaled_params) for _ in range(0, 1000)])
+            latest_prediction
+        )
+        prediction_samples = np.array(
+            [ergo.logistic.sample_mixture(scaled_params) for _ in range(0, 1000)]
+        )
 
         assert np.mean(self.mock_samples) == pytest.approx(
-            np.mean(prediction_samples), np.mean(prediction_samples)/10)
+            np.mean(prediction_samples), np.mean(prediction_samples) / 10
+        )
 
     def test_submitted_equals_predicted_log(self):
         self.continuous_log_open_question.submit_from_samples(self.mock_samples)
-        latest_prediction = self.continuous_log_open_question.get_latest_normalized_prediction()
-        prediction_samples = np.array([
-            self.continuous_log_open_question.true_from_normalized_value(
-                ergo.logistic.sample_mixture(latest_prediction)) for _ in range(0, 5000)])
+        latest_prediction = (
+            self.continuous_log_open_question.get_latest_normalized_prediction()
+        )
+        prediction_samples = np.array(
+            [
+                self.continuous_log_open_question.true_from_normalized_value(
+                    ergo.logistic.sample_mixture(latest_prediction)
+                )
+                for _ in range(0, 5000)
+            ]
+        )
 
         assert np.mean(self.mock_samples) == pytest.approx(
-            np.mean(prediction_samples), np.mean(prediction_samples)/10)
+            np.mean(prediction_samples), np.mean(prediction_samples) / 10
+        )
 
     # smoke tests
     def test_get_community_prediction_linear(self):


### PR DESCRIPTION
@stuhlmueller this is just running `black` over everything

IMO:

1. makes nothing worse
2. makes some things noticeably better
3. most of the changes I don't really care about

note that there are [a few](https://black.readthedocs.io/en/stable/installation_and_usage.html) things you can configure, if you really want to

I'm still in favor of switching to black and I wouldn't change any of the defaults

let me know what you think -- if you're into it then I can:

1. make sure that `flake8` is still the best choice for CI
2. change the README re: what formatter to use