### PR TITLE
Fix random_choice for case where we don't pass in probabilities

### DIFF
--- a/ergo/ppl.py
+++ b/ergo/ppl.py
@@ -119,11 +119,12 @@ def beta_from_hits(hits, total, **kwargs):
 
 
 def random_choice(options, ps=None):
-    # in case ps are passed in as some array-like type other than torch.Tensor
-    ps = torch.Tensor(ps)
-
     if ps is None:
         ps = torch.Tensor([1 / len(options)] * len(options))
+    else:
+        # in case ps are passed in as some array-like type other than torch.Tensor
+        ps = torch.Tensor(ps)
+
     idx = sample(dist.Categorical(ps))
     return options[idx]
 


### PR DESCRIPTION
Was giving me an error torch.Tensor(None) isn't valid.