### PR TITLE
Add sphinx-autodoc-typehints to project dependencies [!pr]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ typing_extensions = "3.7.4.2"
 jax = "0.1.63"
 jaxlib = "0.1.44"
 pandas = "1.0.3"
+sphinx-autodoc-typehints = "^1.10.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"
@@ -35,7 +36,6 @@ pytest-cov = "^2.8.1"
 isort = "^4.3.21"
 sphinx = "^3.0.1"
 sphinx_rtd_theme = "^0.4.3"
-sphinx-autodoc-typehints = "^1.10.3"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Readthedocs doesn't install dev dependencies