### PR TITLE
Import tqdm from tqdm.autonotebook

### DIFF
--- a/ergo/logistic.py
+++ b/ergo/logistic.py
@@ -11,7 +11,7 @@ import numpy as onp
 import scipy as oscipy
 import seaborn
 import torch
-from tqdm.autonotebook import tqdm
+from tqdm.autonotebook import tqdm  # type: ignore
 
 from ergo.ppl import categorical
 

--- a/ergo/logistic.py
+++ b/ergo/logistic.py
@@ -11,7 +11,7 @@ import numpy as onp
 import scipy as oscipy
 import seaborn
 import torch
-import tqdm
+from tqdm.autonotebook import tqdm
 
 from ergo.ppl import categorical
 

--- a/ergo/logistic.py
+++ b/ergo/logistic.py
@@ -91,7 +91,7 @@ def fit_mixture(
     components = initialize_components(num_components)
     (init_fun, update_fun, get_params) = sgd(step_size)
     opt_state = init_fun(components)
-    for i in tqdm.trange(num_samples):
+    for i in tqdm(range(num_samples)):
         components = get_params(opt_state)
         grads = -grad_mixture_logpdf(data_as_np_array, components)
         if np.any(np.isnan(grads)):

--- a/ergo/ppl.py
+++ b/ergo/ppl.py
@@ -158,7 +158,7 @@ def run(model, num_samples=5000, ignore_unnamed=True) -> pd.DataFrame:
     """
     model = name_count(model)
     samples: List[Dict[str, float]] = []
-    for _ in tqdm.trange(num_samples):
+    for _ in tqdm(range(num_samples)):
         sample: Dict[str, float] = {}
         trace = pyro.poutine.trace(model).get_trace()
         for name in trace.nodes.keys():

--- a/ergo/ppl.py
+++ b/ergo/ppl.py
@@ -12,7 +12,7 @@ from pyro.contrib.autoname import name_count
 import pyro.distributions as dist  # type: ignore
 from pyro.infer import SVI, Predictive, Trace_ELBO  # type: ignore
 import torch
-import tqdm
+from tqdm.autonotebook import tqdm
 
 # Config
 

--- a/ergo/ppl.py
+++ b/ergo/ppl.py
@@ -12,7 +12,7 @@ from pyro.contrib.autoname import name_count
 import pyro.distributions as dist  # type: ignore
 from pyro.infer import SVI, Predictive, Trace_ELBO  # type: ignore
 import torch
-from tqdm.autonotebook import tqdm
+from tqdm.autonotebook import tqdm  # type: ignore
 
 # Config
 


### PR DESCRIPTION
This allows `tqdm` to detect whether it's being used in a notebook or in a console.

When `tqdm` is imported from `tqdm.autonotebook`, `tqdm.trange(...)` no longer works, so we needed to switch to `tqdm(range(...))`.

Also, `tqdm.autonotebook` doesn't come with any type hints, so we needed to add `# type: ignore` to suppress the errors for now. Maybe in the future we can add our own type hints here?

Resolves #127 