### PR TITLE
Metaculus questions default names

### DIFF
--- a/ergo/metaculus.py
+++ b/ergo/metaculus.py
@@ -1118,6 +1118,8 @@ class Metaculus:
         :param name: a custom name for the question
         :return: A MetaculusQuestion from the appropriate subclass
         """
+        if not name:
+            name = data.get("title")
         if data["possibilities"]["type"] == "binary":
             return BinaryQuestion(data["id"], self, data, name)
         if data["possibilities"]["type"] == "continuous":


### PR DESCRIPTION
Simple first change. 
If a question doesn't have a name, it defaults to the question title.