### PR TITLE
now no additional question refresh necessary

### DIFF
--- a/ergo/metaculus.py
+++ b/ergo/metaculus.py
@@ -1272,6 +1272,11 @@ class Metaculus:
 
         questions = get_questions_for_pages(query_string, pages)
 
+        # add additional fields ommited from previous query
+        for i, _q in enumerate(questions):
+            _r = self.s.get(f"{self.api_url}/questions/{_q['id']}")
+            questions[i] = dict(_r.json(), **_q)
+
         if not include_discussion_questions:
             questions = [
                 q for q in questions if q["possibilities"]["type"] != "discussion"

--- a/ergo/metaculus.py
+++ b/ergo/metaculus.py
@@ -1273,9 +1273,9 @@ class Metaculus:
         questions = get_questions_for_pages(query_string, pages)
 
         # add additional fields ommited from previous query
-        for i, _q in enumerate(questions):
-            _r = self.s.get(f"{self.api_url}/questions/{_q['id']}")
-            questions[i] = dict(_r.json(), **_q)
+        for i, q in enumerate(questions):
+            r = self.s.get(f"{self.api_url}/questions/{q['id']}")
+            questions[i] = dict(r.json(), **q)
 
         if not include_discussion_questions:
             questions = [


### PR DESCRIPTION
The Stupid Quick Fix to #125 (but does not address the more complicated requirements)

The query in get_questions_json ommits the following fields returned by the simpler query in get_question and refresh_question
simple query: `self.s.get(f"{self.api_url}/questions/{id}")`
additional fields: [author_name, prediction_histogram ,anon_prediction_count, last_read]

(Conversely the get_question_json query returns the field comment_count_snapshot, not present in the simple query (given very preliminary testing))

The present pull request just takes the union of the results but likely a more elegant solution can be found by investigating the queries and api responses more closely

