### PR TITLE
Fit logistic mixture using BFGS instead of SGD

### DIFF
--- a/ergo/logistic.py
+++ b/ergo/logistic.py
@@ -1,14 +1,12 @@
 from dataclasses import dataclass
-from pprint import pprint
+import itertools
 from typing import List
 
 from jax import grad, jit, nn, scipy, vmap
-from jax.experimental.optimizers import clip_grads, sgd
 from jax.interpreters.xla import DeviceArray
 import jax.numpy as np
 import numpy as onp
 import scipy as oscipy
-from tqdm.autonotebook import tqdm
 
 from ergo.distributions import categorical
 
@@ -18,11 +16,23 @@ class LogisticParams:
     loc: float
     scale: float
 
+    def __init__(self, loc: float, scale: float):
+        self.loc = loc
+        self.scale = max(scale, 0.0000001)  # Do not allow values <= 0
+
+    def __mul__(self, x):
+        return LogisticParams(self.loc * x, self.scale * x)
+
 
 @dataclass
 class LogisticMixtureParams:
     components: List[LogisticParams]
     probs: List[float]
+
+    def __mul__(self, x):
+        return LogisticMixtureParams(
+            [component * x for component in self.components], self.probs
+        )
 
 
 def fit_single_scipy(samples) -> LogisticParams:
@@ -51,7 +61,8 @@ def mixture_logpdf_single(datum, components):
 
 
 @jit
-def mixture_logpdf(data, components):
+def mixture_logpdf(data, component_params):
+    components = component_params.reshape((-1, 3))
     scores = vmap(lambda datum: mixture_logpdf_single(datum, components))(data)
     return np.sum(scores)
 
@@ -60,16 +71,23 @@ grad_mixture_logpdf = jit(grad(mixture_logpdf, argnums=1))
 
 
 def initialize_components(num_components):
-    # Each component has (location, scale, weight)
-    # Weights sum to 1 (are given in log space)
-    # We use onp to initialize parameters since we don't want to track
-    # randomness
+    """
+    Each component has (location, scale, weight).
+    The shape of the components matrix is (num_components, 3).
+    Weights sum to 1 (are given in log space).
+    We use original numpy to initialize parameters since we don't
+    want to track randomness.
+    """
     components = onp.random.rand(num_components, 3) * 0.1 + 1.0
     components[:, 2] = -num_components
-    return components
+    component_params = components.reshape(-1)
+    bounds = [((None, None), (0.01, None), (None, None)) for _ in range(num_components)]
+    bound_params = list(itertools.chain.from_iterable(bounds))
+    return component_params, bound_params
 
 
-def structure_mixture_params(components) -> LogisticMixtureParams:
+def structure_mixture_params(component_params) -> LogisticMixtureParams:
+    components = component_params.reshape((-1, 3))
     unnormalized_weights = components[:, 2]
     probs = list(np.exp(nn.log_softmax(unnormalized_weights)))
     component_params = [
@@ -78,32 +96,20 @@ def structure_mixture_params(components) -> LogisticMixtureParams:
     return LogisticMixtureParams(components=component_params, probs=probs)
 
 
-def fit_mixture(
-    data, num_components=3, verbose=False, num_samples=5000
-) -> LogisticMixtureParams:
-    # the data might be something weird, like a pandas dataframe column;
-    # turn it into a regular old numpy array
-    data_as_np_array = np.array(data)
-    step_size = 0.01
-    components = initialize_components(num_components)
-    (init_fun, update_fun, get_params) = sgd(step_size)
-    opt_state = init_fun(components)
-    for i in tqdm(range(num_samples)):
-        components = get_params(opt_state)
-        grads = -grad_mixture_logpdf(data_as_np_array, components)
-        if np.any(np.isnan(grads)):
-            if verbose:
-                print("Encoutered nan gradient, stopping early")
-                print(grads)
-                print(components)
-            break
-        grads = clip_grads(grads, 1.0)
-        opt_state = update_fun(i, grads, opt_state)
-        if i % 500 == 0 and verbose:
-            pprint(components)
-            score = mixture_logpdf(data_as_np_array, components)
-            print(f"Log score: {score:.3f}")
-    return structure_mixture_params(components)
+def fit_mixture(data, num_components=3, verbose=False) -> LogisticMixtureParams:
+    data = np.array(data)
+    z = float(np.mean(data))
+    normalized_data = data / z
+    component_params, _ = initialize_components(num_components)
+    fit_results = oscipy.optimize.minimize(
+        lambda comps: -mixture_logpdf(normalized_data, comps),
+        x0=component_params,
+        jac=lambda comps: -grad_mixture_logpdf(normalized_data, comps),
+    )
+    if not fit_results.success and verbose:
+        print(fit_results)
+    component_params = fit_results.x
+    return structure_mixture_params(component_params) * z
 
 
 def fit_single(samples) -> LogisticParams:

--- a/ergo/metaculus.py
+++ b/ergo/metaculus.py
@@ -501,7 +501,8 @@ class ContinuousQuestion(MetaculusQuestion):
             # [or if you set the high lower], then the API will reject the prediction,
             # though we haven't tested that extensively)
             min_open_low = 0.01
-            low = max(distribution.cdf(0), min_open_low)
+            max_open_low = 0.98
+            low = min(max(distribution.cdf(0), min_open_low), max_open_low)
         else:
             low = 0
 
@@ -510,7 +511,6 @@ class ContinuousQuestion(MetaculusQuestion):
             # https://www.metaculus.com/api2/questions/3961/predict/ --
             # {'prediction': ['high minus low must be at least 0.01']}"
             min_open_high = low + 0.01
-
             max_open_high = 0.99
             high = max(min(distribution.cdf(1), max_open_high), min_open_high)
         else:

--- a/ergo/metaculus.py
+++ b/ergo/metaculus.py
@@ -470,7 +470,9 @@ class ContinuousQuestion(MetaculusQuestion):
         :param logistic_params: params for a logistic on the normalized scale
         :return: params to submit the logistic to Metaculus as part of a prediction
         """
-        assert logistic_params.scale > 0
+        if logistic_params.scale <= 0:
+            raise ValueError("logistic_params.scale must be greater than 0")
+
         distribution = stats.logistic(logistic_params.loc, logistic_params.scale)
 
         # The loc and scale have to be within a certain range for the

--- a/ergo/metaculus.py
+++ b/ergo/metaculus.py
@@ -594,7 +594,9 @@ class ContinuousQuestion(MetaculusQuestion):
             for logistic_params in mixture_params.components
         ]
 
-        return SubmissionMixtureParams(submission_logistic_params, mixture_params.probs)
+        submission_probs = [min(max(0.01, p), 0.99) for p in mixture_params.probs]
+
+        return SubmissionMixtureParams(submission_logistic_params, submission_probs)
 
     def get_submission_from_samples(
         self, samples: Union[pd.Series, np.ndarray], verbose=False

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -2,7 +2,8 @@ import jax.numpy as np
 import numpy as onp
 import pytest
 
-from ergo.logistic import fit_mixture, fit_single, fit_single_scipy
+from ergo.logistic import fit_mixture, fit_single, fit_single_scipy, sample_mixture
+import tests.mocks
 
 
 def test_fit_single_scipy():
@@ -44,13 +45,17 @@ def test_fit_mixture_large():
     assert scales[1] == pytest.approx(0.2, abs=0.2)
 
 
-# visual tests, comment out usually
-
-# def test_visual_plot_mixture():
-#     samples = onp.concatenate(
-#         [onp.random.normal(loc=0.1, scale=0.1, size=1500),
-#          onp.random.normal(loc=0.5, scale=0.1, size=1500),
-#          onp.random.logistic(loc=0.9, scale=0.1, size=2000)])
-#     onp.random.shuffle(samples)
-#     mixture_params = fit_mixture(samples, num_components=5, num_samples=1000)
-#     plot_mixture(mixture_params, samples)
+def test_fit_samples():
+    data = np.array(
+        [sample_mixture(tests.mocks.mock_true_params) for _ in range(0, 1000)]
+    )
+    true_params = tests.mocks.mock_true_params
+    fitted_params = fit_mixture(data, num_components=2)
+    true_locs = sorted([component.loc for component in true_params.components])
+    true_scales = sorted([component.scale for component in true_params.components])
+    fitted_locs = sorted([component.loc for component in fitted_params.components])
+    fitted_scales = sorted([component.scale for component in fitted_params.components])
+    for (true_loc, fitted_loc) in zip(true_locs, fitted_locs):
+        assert fitted_loc == pytest.approx(true_loc, rel=0.2)
+    for (true_scale, fitted_scale) in zip(true_scales, fitted_scales):
+        assert fitted_scale == pytest.approx(true_scale, rel=0.2)

--- a/tests/test_metaculus.py
+++ b/tests/test_metaculus.py
@@ -126,9 +126,7 @@ class TestMetaculus:
         assert r.status_code == 202
 
     def test_submit_from_samples(self):
-        r = self.continuous_linear_open_question.submit_from_samples(
-            self.mock_samples, samples_for_fit=1000
-        )
+        r = self.continuous_linear_open_question.submit_from_samples(self.mock_samples)
         assert r.status_code == 202
 
     def test_submit_binary(self):


### PR DESCRIPTION
- Would be better to use [BFGS with bounds](https://docs.scipy.org/doc/scipy/reference/optimize.minimize-lbfgsb.html) but I ran into issues, probably caused by use of Jax arrays (and couldn't easily make it work).
- Improves fitting speed from ~13s to ~1s for [a typical case](https://github.com/oughtinc/ergo/pull/284/files#diff-3a3f306d1a1573e1a5d9916ca51c3b8aR48).