### PR TITLE
add cdf and ppf functions for logistic mixtures

### DIFF
--- a/ergo/logistic.py
+++ b/ergo/logistic.py
@@ -74,20 +74,18 @@ def mixture_cdf(x: float, logistic_mixture_params: LogisticMixtureParams) -> flo
 
 def mixture_ppf(
     p, logistic_mixture_params
-):  # TODO consider whetehr this should be part of abstract dist class
+):  # TODO consider whether this should be part of abstract dist class
     # Numerically determine the quantile for the mixture provided
 
-    lo = np.min(
-        [component.dist().ppf(p) for component in logistic_mixture_params.components]
-    )
-    hi = np.max(
-        [component.dist().ppf(p) for component in logistic_mixture_params.components]
-    )
+    ppfs = [c.dist().ppf(p) for c in logistic_mixture_params.components]
 
     # return the smallest quantile from mixture_cdf that
     # is larger than the one requested
     return oscipy.optimize.bisect(
-        lambda x: mixture_cdf(x, logistic_mixture_params) - p, lo, hi, maxiter=1000
+        lambda x: mixture_cdf(x, logistic_mixture_params) - p,
+        np.min(ppfs),
+        np.max(ppfs),
+        maxiter=1000,
     )
 
 

--- a/ergo/logistic.py
+++ b/ergo/logistic.py
@@ -29,9 +29,6 @@ class LogisticParams:
         return oscipy.stats.logistic(loc=self.loc, scale=self.scale)
 
 
-
-
-
 @dataclass
 class LogisticMixtureParams:
     components: List[LogisticParams]

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -2,7 +2,14 @@ import jax.numpy as np
 import numpy as onp
 import pytest
 
-from ergo.logistic import fit_mixture, fit_single, fit_single_scipy
+from ergo.logistic import (
+    fit_mixture,
+    fit_single,
+    fit_single_scipy,
+    mixture_cdf,
+    mixture_ppf,
+    structure_mixture_params,
+)
 
 
 def test_fit_single_scipy():
@@ -42,6 +49,29 @@ def test_fit_mixture_large():
     assert locs[1] == pytest.approx(0.7, abs=0.2)
     assert scales[0] == pytest.approx(0.1, abs=0.2)
     assert scales[1] == pytest.approx(0.2, abs=0.2)
+
+
+def test_mixture_cdf():
+    mock_logistic_params = np.array([[10, 3.658268, 0.5], [20, 3.658268, 0.5]])
+    mock_mixture = structure_mixture_params(mock_logistic_params)
+    cdf50 = mixture_cdf(15, mock_mixture)
+    assert cdf50 == pytest.approx(0.5, rel=1e-3)
+
+
+def test_mixture_ppf():
+    mock_logistic_params = np.array([[15, 2.3658268, 0.5], [5, 2.3658268, 0.5]])
+    mock_mixture = structure_mixture_params(mock_logistic_params)
+    ppf5 = mixture_ppf(0.5, mock_mixture)
+    assert ppf5 == pytest.approx(10, rel=1e-3)
+
+    # test round-trip
+    mock_mixture = fit_mixture(
+        np.array([0.5, 0.4, 0.8, 0.8, 0.9, 0.95, 0.15, 0.1]), num_components=3
+    )
+    x = 0.65
+    assert mixture_ppf(mixture_cdf(x, mock_mixture), mock_mixture) == pytest.approx(
+        x, rel=1e-3
+    )
 
 
 # visual tests, comment out usually

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -8,8 +8,8 @@ from ergo.logistic import (
     fit_single_scipy,
     mixture_cdf,
     mixture_ppf,
-    structure_mixture_params,
     sample_mixture,
+    structure_mixture_params,
 )
 import tests.mocks
 
@@ -52,6 +52,7 @@ def test_fit_mixture_large():
     assert scales[0] == pytest.approx(0.1, abs=0.2)
     assert scales[1] == pytest.approx(0.2, abs=0.2)
 
+
 def test_mixture_cdf():
     # make a mock with known properties. The median should be 15 for this mixture
     mock_logistic_params = np.array([[10, 3.658268, 0.5], [20, 3.658268, 0.5]])
@@ -72,6 +73,10 @@ def ppf_cdf_round_trip():
     mock_mixture = fit_mixture(
         np.array([0.5, 0.4, 0.8, 0.8, 0.9, 0.95, 0.15, 0.1]), num_components=3
     )
+    x = 0.65
+    prob = mixture_cdf(x, mock_mixture)
+    assert mixture_ppf(prob, mock_mixture) == pytest.approx(x, rel=1e-3)
+
 
 def test_fit_samples():
     data = np.array(

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -52,6 +52,7 @@ def test_fit_mixture_large():
 
 
 def test_mixture_cdf():
+    # make a mock with known properties. The median should be 15 for this mixture
     mock_logistic_params = np.array([[10, 3.658268, 0.5], [20, 3.658268, 0.5]])
     mock_mixture = structure_mixture_params(mock_logistic_params)
     cdf50 = mixture_cdf(15, mock_mixture)
@@ -59,19 +60,20 @@ def test_mixture_cdf():
 
 
 def test_mixture_ppf():
+    # make a mock with known properties. The median should be 10 for this mixture
     mock_logistic_params = np.array([[15, 2.3658268, 0.5], [5, 2.3658268, 0.5]])
     mock_mixture = structure_mixture_params(mock_logistic_params)
     ppf5 = mixture_ppf(0.5, mock_mixture)
     assert ppf5 == pytest.approx(10, rel=1e-3)
 
-    # test round-trip
+
+def ppf_cdf_round_trip():
     mock_mixture = fit_mixture(
         np.array([0.5, 0.4, 0.8, 0.8, 0.9, 0.95, 0.15, 0.1]), num_components=3
     )
     x = 0.65
-    assert mixture_ppf(mixture_cdf(x, mock_mixture), mock_mixture) == pytest.approx(
-        x, rel=1e-3
-    )
+    prob = mixture_cdf(x, mock_mixture)
+    assert mixture_ppf(prob, mock_mixture) == pytest.approx(x, rel=1e-3)
 
 
 # visual tests, comment out usually


### PR DESCRIPTION
Did enough research to be convinced that the numeric ppf approximation is the way to go (some notes [here](https://docs.google.com/document/d/1K4mmR3BtvCCKGwcvjczn5KAeTz3frdT7JIgRz7uPXwE/edit#). It should work for arbitrary mixtures. If a special case becomes important we can consider hunting for analytic solutions, but that is overkill for now. 

Notes:

Currently we have a lot of logistic-specific functionality, but it might make sense to have a more abstract distribution class if we want to support many distribution types in the dist builder. E.g. mixture_cdf should be in the abstract class and delegate to the cdf function of the appropriate class (in this case Logistic). My suspicion is that you structured things as they are with jax and speed in mind, which is above my paygrade. So I didn't want to refactor so I just made it work as-is for now. Additionally I wonder what the pros/cons of making the params the thing passed around instead of the actual dist objects. On that note, I added a dist getter to the base logistic params class. Perhaps that would be better as a normal field, but then I should write a repr to keep it from printing. 
