### PR TITLE
Copy edit El Paso notebook for clarity

### DIFF
--- a/notebooks/src/el-paso-workflow.ipynb
+++ b/notebooks/src/el-paso-workflow.ipynb
@@ -81,9 +81,9 @@
     "\n",
     "I want to predict the answer to this question:\n",
     "\n",
-    "> How many ventilators will be needed for COVID patients in El Paso county in May? (On the day when the most ventilators are needed, how many will be needed?)\n",
+    "> In El Paso, what is the maximum number of ventilators needed for COVID patients on a given day in May?\n",
     "\n",
-    "For this tutorial, we'll pretend that we're making the prediction at the end of April -- we'll only use information that we could have had at that time.\n",
+    "In other words: on the day when most ventilators are needed, how many will be needed? For this tutorial, we'll pretend that we're making the prediction at the end of April -- we'll only use information that we could have had at that time.\n",
     "\n",
     "Background:\n",
     "\n",
@@ -194,14 +194,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Why sample instead of manipulating distributions directly?\n",
+    "Why sample instead of manipulating distributions directly? To use distributions in our prediction, we need to be able to combine distributions for sub-predictions together. Combining distributions can be difficult, as it requires non-trivial math. \n",
     "\n",
-    "As I build out my model, we'll see that: \n",
-    "\n",
-    "- Composing samplers is easy - it's just programming as usual\n",
-    "- Composing probability distributions is hard - it's math\n",
-    "\n",
-    "I'll build up complex models by composing samplers."
+    "Ergo allows you to create samplers (like the `ergo.lognormal_from_interval` above), which you can compose together using regular python operators (`*, +, -`). This allows you to focus on how you're modeling the problem, rather than the math. I'll build a complex model for this problem by composising samplers together."
    ]
   },
   {
@@ -238,7 +233,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "I'll wrap my guess in a `Model` class so that I can more easily build on it step by step by inheriting from the class, adding more methods, and replacing methods with better implementations:"
+    "I'll wrap my guess in a `Model` class so that I can more easily build on it step by step by inheriting from the class, adding more methods, and replacing methods with better implementations. This also lets me see how my prediction changes as I make it more sophisticated. "
    ]
   },
   {
@@ -312,7 +307,7 @@
     "For both of these I'll make pretty uninformed guesses for now:\n",
     "\n",
     "1. I guess that about 5 to 200 people will be the maximum number of people in the ICU (but I have no idea)\n",
-    "2. I'd guess that 1 out of 3 will need ventilators (but I have no idea)"
+    "2. I'd guess that 1 out of 3 will need ventilators (another uninformed guess)"
    ]
   },
   {
@@ -346,8 +341,8 @@
     "I'll use a beta-binomial distribution via `ergo.beta_from_hits`.\n",
     "\n",
     "`ergo.beta_from_hits`:\n",
-    "1. Assumes that there's some constant underlying probability that a condition is met in a situation (in this case, that a patient will be on a ventilator given that they're in the ICU)\n",
-    "2. Takes in a number of observations of the situation (patients in the ICU, who may or may not be on ventilators)\n",
+    "1. Assumes that there's some constant underlying probability that a condition is met in a situation (in this case, the condition is: a patient will be on a ventilator given that they're in the ICU)\n",
+    "2. Takes in a number of observations of the situation (patients in the ICU) and the number of observations that met the condition (number of patients in the ICU who needed a ventilator)\n",
     "3. Returns a sample from the beta-binomial distribution of underlying probabilities that the condition is met in the situation (again, the probability that a patient will be on a ventilator given that they're in the ICU)\n",
     "\n",
     "[This explanation](http://varianceexplained.org/statistics/beta_distribution_and_baseball/) helped me understand it.\n",
@@ -419,7 +414,11 @@
     "        return ergo.beta_from_hits(1, 3)\n",
     "    \n",
     "    def run(self):\n",
+    "        # we want to be able to compare versions of the model as we change it, so we use some python \n",
+    "        # metaprogramming to compute the prediction from our previous model.\n",
     "        prev_model_samples = ergo.run(self.__class__.__bases__[0]().ventilators_needed, num_samples=1000)[\"output\"]\n",
+    "        \n",
+    "        # we then plot them against one another, showing how the model has changed\n",
     "        this_model_samples = ergo.run(self.ventilators_needed, num_samples=1000)[\"output\"]\n",
     "        samples_df = pd.DataFrame(data={\"Previous model\": prev_model_samples, \"This model\": this_model_samples})\n",
     "        ventilators_question.show_prediction(samples_df); plt.show()\n",
@@ -696,9 +695,9 @@
     "1. There are 100 patients in the ICU\n",
     "2. 1/2 of ICU patients need ventilation at some point during their stay\n",
     "\n",
-    "Then `(max # icu patients) * (% icu patients that need ventilation at some point while in the ICU)` = 50.\n",
+    "Then `(max # icu patients) * (% icu patients that need ventilation at some point while in the ICU)` = 50. This may give too high an estimate of ventilators needed. \n",
     "\n",
-    "`(max # icu patients) * (% icu patients that need ventilation at some point while in the ICU)` may give too high an estimate of ventilators needed. Imagine that:\n",
+    "Imagine that:\n",
     "1. Patients who will need ventilation at some point during their ICU stay remain in the ICU for the same total amount of time as ICU patients who will never need ventilation\n",
     "2. ICU patients only need ventilation for 1/2 of their ICU stay\n",
     "\n",
@@ -746,7 +745,7 @@
     "- \\# ventilators needed =\n",
     "  - max # icu patients *\n",
     "  - % of icu patients ventilated\n",
-    "      - \\% icu patients that need ventilation at some point while in the ICU *\n",
+    "      - \\% icu patients that need ventilation at some point while in the ICU\n",
     "      - icu-ventilation adjustment\n",
     "\n",
     "Updating my model with the new decomposition and submodels:"
@@ -858,7 +857,7 @@
     "The implicit community prediction is similar to my model prediction, but much less confident.\n",
     "\n",
     "## My new model - now with ensembling!\n",
-    "I can combine my prediction and the community prediction into an ensembled prediction. I'll sample from the Metaculus community prediction half the time, and from the Metaculus community prediction half the time."
+    "I can combine my prediction and the community prediction into an ensembled prediction. I'll sample from the Metaculus community prediction half the time, and from my model half the time."
    ]
   },
   {
@@ -976,7 +975,7 @@
     "- **\\# ventilators needed [Result: 44.82 (7.12 to 608.06)]** =\n",
     "  - max # icu patients [Result: 106.50 (22.00 to 1174.00). Source: [Columbia model](https://github.com/shaman-lab/COVID-19Projection)] *\n",
     "  - % of icu patients ventilated [Result: 0.43 (0.16 to 1.02)] =\n",
-    "      - \\% icu patients that need ventilation at some point while in the ICU [Result: 0.51 (0.22 to 1.03). Source: [PabloStafforini et al.](https://pandemic.metaculus.com/questions/4154/what-portion-of-in-hospital-patients-with-covid-19-in-el-paso-county-will-require-invasive-ventilation/#comment-28155)] *\n",
+    "      - \\% icu patients that need ventilation at some point while in the ICU [Result: 0.51 (0.22 to 1.03). Source: combination of [PabloStafforini et al.](https://pandemic.metaculus.com/questions/4154/what-portion-of-in-hospital-patients-with-covid-19-in-el-paso-county-will-require-invasive-ventilation/#comment-28155)] and Metaculus community prediction*\n",
     "      - icu-ventilation adjustmen [Result: 0.88 (0.51 to 1.52). Source: guess.]"
    ]
   },

--- a/notebooks/src/el-paso-workflow.ipynb
+++ b/notebooks/src/el-paso-workflow.ipynb
@@ -196,7 +196,7 @@
    "source": [
     "Why sample instead of manipulating distributions directly? To use distributions in our prediction, we need to be able to combine distributions for sub-predictions together. Combining distributions can be difficult, as it requires non-trivial math. \n",
     "\n",
-    "Ergo allows you to create samplers (like the `ergo.lognormal_from_interval` above), which you can compose together using regular python operators (`*, +, -`). This allows you to focus on how you're modeling the problem, rather than the math. I'll build a complex model for this problem by composising samplers together."
+    "Ergo allows you to create samplers (like the `ergo.lognormal_from_interval` above), which you can compose together using regular python operators (`*, +, -`). This allows you to focus on how you're modeling the problem, rather than the math. I'll build a complex model for this problem by composing samplers together."
    ]
   },
   {


### PR DESCRIPTION
This doesn't get it to a point where I think it would work for a public
tutorial (will open a future PR for that), but helps make
it clearer.

Tried to add some copy editing here to:

- correct some errors (repeating a phrase, listing a footnote where
there wasn't one, etc)
- add clarity (rephrased some things that I thought were confusing,
tried to improve explanations if there were low hanging fruit)