### PR TITLE
made mixture ppf more robust

### DIFF
--- a/ergo/distributions/mixture.py
+++ b/ergo/distributions/mixture.py
@@ -56,12 +56,17 @@ class Mixture(Distribution):
         if len(self.components) == 1:
             return self.components[0].ppf(q)
         ppfs = [c.ppf(q) for c in self.components]
-        return oscipy.optimize.bisect(
-            lambda x: self.cdf(x) - q,
-            np.min(ppfs) - 0.01,
-            np.max(ppfs) + 0.01,
-            maxiter=1000,
-        )
+        cmin = np.min(ppfs)
+        cmax = np.max(ppfs)
+        try:
+            return oscipy.optimize.bisect(
+                lambda x: self.cdf(x) - q,
+                cmin - abs(cmin / 100),
+                cmax + abs(cmax / 100),
+                maxiter=1000,
+            )
+        except ValueError:
+            return (cmax + cmin) / 2
 
     def sample(self):
         i = categorical(np.array(self.probs))

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -86,6 +86,20 @@ def test_mixture_ppf_adversarial():
     assert mixture.ppf(0.99) == pytest.approx(27.9755, rel=1e-3)
     assert mixture.ppf(0.999) == pytest.approx(39.5337, rel=1e-3)
 
+    # Make a mixture with hugely overlapping distributions
+    mixture = LogisticMixture(
+        [
+            Logistic(4000000.035555004, 200000.02),
+            Logistic(4000000.0329152746, 200000.0),
+        ],
+        [0.5, 0.5],
+    )
+    assert mixture.ppf(0.5) == pytest.approx(4000000.0342351394, rel=1e-3)
+    assert mixture.ppf(0.01) == pytest.approx(3080976.018257023, rel=1e-3)
+    assert mixture.ppf(0.001) == pytest.approx(2618649.009437881, rel=1e-3)
+    assert mixture.ppf(0.99) == pytest.approx(4919024.050213255, rel=1e-3)
+    assert mixture.ppf(0.999) == pytest.approx(5381351.059032397, rel=1e-3)
+
 
 def ppf_cdf_round_trip():
     mixture = LogisticMixture.from_samples(


### PR DESCRIPTION
fixes #322

More robust extension of the min/max quartile range given the optimization function. Additionally, if there is an unexpected edgecase provide a fallback value (which for the cases tested is very close to the optimization-computed value)