### PR TITLE
HistogramDist fixes

### DIFF
--- a/ergo/distributions/histogram.py
+++ b/ergo/distributions/histogram.py
@@ -58,10 +58,18 @@ class HistogramDist(distribution.Distribution):
         return -np.dot(self.ps, q_dist.logps)
 
     def pdf(self, x):
-        return self.ps[np.argmax(self.bins >= self.scale.normalize_point(x))]
+        return np.where(
+            (x < self.scale_min) | (x > self.scale_max),
+            0, 
+            self.ps[np.argmax(self.bins >= x) - 1],
+        )
 
     def cdf(self, x):
-        return self.cum_ps[np.argmax(self.bins >= self.scale.normalize_point(x))]
+        return np.where(
+            x < self.scale_min,
+            0,
+            np.where(x > self.scale_max, 1, self.cum_ps[np.argmax(self.bins >= x) - 1]),
+        )
 
     def ppf(self, q):
         return self.scale.denormalize_point(

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -24,3 +24,42 @@ def test_hist_from_percentile():
         conditions = [IntervalCondition(p=0.5, max=value)]
         dist = HistogramDist.from_conditions(conditions)
         assert dist.ppf(0.5) == pytest.approx(value, abs=0.1)
+
+
+def test_hist_pdf():
+    uniform_dist = HistogramDist.from_conditions([])
+
+    # Off of scale
+    assert uniform_dist.pdf(-0.5) == 0
+    assert uniform_dist.pdf(1.5) == 0
+
+    # Denormalized
+    denormalized_dist = uniform_dist.denormalize(scale_min=0, scale_max=2)
+    assert denormalized_dist.pdf(1.5) != 0
+    assert denormalized_dist.pdf(2.5) == 0
+
+
+def test_hist_cdf():
+    uniform_dist = HistogramDist.from_conditions([])
+
+    # Off of scale
+    assert uniform_dist.cdf(-0.5) == 0
+    assert uniform_dist.cdf(1.5) == 1
+
+    # Edges of scale
+    assert uniform_dist.cdf(0.005) != uniform_dist.cdf(0.015)
+    assert uniform_dist.cdf(0.985) != uniform_dist.cdf(0.995)
+
+    # Denormalized
+    denormalized_dist = uniform_dist.denormalize(scale_min=0, scale_max=2)
+    assert denormalized_dist.cdf(1) == pytest.approx(0.5, abs=0.01)
+    assert denormalized_dist.cdf(1.5) != 0
+    assert denormalized_dist.cdf(2.5) == 1
+
+
+def test_hist_ppf():
+    uniform_dist = HistogramDist.from_conditions([])
+
+    # Ends of scale; second is approx since implemented as start of last bin
+    assert uniform_dist.ppf(0) == 0
+    assert uniform_dist.ppf(1) == pytest.approx(1, abs=0.01)


### PR DESCRIPTION
Bugs fixed:
- `pdf` and `cdf` not working when distribution isn't normalized.
- `pdf` and `cdf` returning wrong values when out `x` below `scale_min` or above `scale_max`.
- `ppf` sometimes erroring when `scale_max` is passed in (since the highest value in `cum_ps` is sometimes something like `scale_max`-.0001).
- Off by 1 error: Before if the `bins` was [0,0.5,1] and `ps` was [0.4,0.6] `pdf(0.25)` would have been 0.6, and `cdf(0.5)` 1. In other words the returned index in `ps`/`cum_ps` was one to the right of the correct value.