### PR TITLE
Fix truncated ppf error [!PR]

### DIFF
--- a/ergo/distributions/truncated_logistic_mixture.py
+++ b/ergo/distributions/truncated_logistic_mixture.py
@@ -46,7 +46,10 @@ class TruncatedLogisticMixture(Mixture, Optimizable):
         Percent point function (inverse of cdf) at q.
         """
         return oscipy.optimize.bisect(
-            lambda x: self.cdf(x) - q, self.floor, self.ceiling, maxiter=1000,
+            lambda x: self.cdf(x) - q,
+            self.floor - 1e-9,
+            self.ceiling + 1e-9,
+            maxiter=1000,
         )
 
     def sample(self):


### PR DESCRIPTION
Similar to #327 which fixed #322, but for truncated logistic mixtures. Fixing error mentioned in [this Elicit PR](https://github.com/oughtinc/elicit/pull/170).

```
Traceback (most recent call last):
  File "test_submission.py", line 81, in test_community_submission
    comparisons.append(DistributionComparator(q_id, dists_to_compare, range_min, range_max))
  File "test_submission.py", line 21, in __init__
    self._calculate_dist_percentiles()
  File "test_submission.py", line 28, in _calculate_dist_percentiles
    self.dist_percentiles[i].append(round(dist.ppf(percentile), 4))
  File "/home/elifland/anaconda3/envs/ought/src/ergo/ergo/distributions/truncated_logistic_mixture.py", line 49, in ppf
    lambda x: self.cdf(x) - q, self.floor, self.ceiling, maxiter=1000,
  File "/home/elifland/anaconda3/envs/ought/lib/python3.6/site-packages/scipy/optimize/zeros.py", line 553, in bisect
    r = _zeros._bisect(f, a, b, xtol, rtol, maxiter, args, full_output, disp)
ValueError: f(a) and f(b) must have different signs
``` 

Since `cdf` returns 0 when less than (but not equal to) `self.floor`, and 1 when greater than `self.ceiling`, we need to subtract/add a small epsilon to ensure `self.cdf(x) - q` has different signs at the next two arguments.