### PR TITLE
Restrict location of logistic mixture based on truncation range

### DIFF
--- a/ergo/distributions/logistic_mixture.py
+++ b/ergo/distributions/logistic_mixture.py
@@ -31,9 +31,10 @@ class LogisticMixture(Mixture, Optimizable):
     @classmethod
     def from_params(cls, fixed_params, opt_params, traceable=True):
         structured_params = opt_params.reshape((-1, 3))
-        unnormalized_weights = structured_params[:, 2]
-        probs = list(nn.softmax(unnormalized_weights))
-        component_dists = [Logistic(p[0], p[1]) for p in structured_params]
+        locs = structured_params[:, 0]
+        scales = np.abs(structured_params[:, 1])
+        probs = list(nn.softmax(structured_params[:, 2]))
+        component_dists = [Logistic(l, s) for (l, s) in zip(locs, scales)]
         return cls(component_dists, probs)
 
     @staticmethod

--- a/ergo/distributions/optimizable.py
+++ b/ergo/distributions/optimizable.py
@@ -39,7 +39,11 @@ class Optimizable(ABC):
             fixed_params = {}
 
         data = np.array(data)
-        scale = Scale(scale_min=min(data), scale_max=max(data))
+        data_range = max(data) - min(data)
+        scale = Scale(
+            scale_min=min(data) - 0.25 * data_range,
+            scale_max=max(data) + 0.25 * data_range,
+        )
         fixed_params = cls.normalize_fixed_params(
             fixed_params, scale.scale_min, scale.scale_max
         )

--- a/ergo/distributions/truncated_logistic_mixture.py
+++ b/ergo/distributions/truncated_logistic_mixture.py
@@ -6,6 +6,7 @@ from typing import Sequence
 
 from jax import nn
 import jax.numpy as np
+import jax.scipy as scipy
 import scipy as oscipy
 
 import ergo.scale as scale
@@ -60,9 +61,10 @@ class TruncatedLogisticMixture(Mixture, Optimizable):
         floor = fixed_params["floor"]
         ceiling = fixed_params["ceiling"]
         structured_params = opt_params.reshape((-1, 3))
-        unnormalized_weights = structured_params[:, 2]
-        probs = list(nn.softmax(unnormalized_weights))
-        component_dists = [Logistic(p[0], p[1]) for p in structured_params]
+        locs = floor + scipy.special.expit(structured_params[:, 0]) * (ceiling - floor)
+        scales = np.abs(structured_params[:, 1])
+        probs = list(nn.softmax(structured_params[:, 2]))
+        component_dists = [Logistic(l, s) for (l, s) in zip(locs, scales)]
         return cls(component_dists, probs, floor, ceiling)
 
     @staticmethod

--- a/ergo/distributions/truncated_logistic_mixture.py
+++ b/ergo/distributions/truncated_logistic_mixture.py
@@ -6,11 +6,10 @@ from typing import Sequence
 
 from jax import nn
 import jax.numpy as np
-import numpy as onp
 import jax.scipy as scipy
+import numpy as onp
 import scipy as oscipy
 
-# import ergo.platforms.metaculus.question.constants as constants
 import ergo.scale as scale
 
 from .logistic import Logistic
@@ -38,7 +37,6 @@ class TruncatedLogisticMixture(Mixture, Optimizable):
         res = np.where(
             x < self.floor, -np.inf, np.where(x > self.ceiling, -np.inf, logp_x)
         )
-        # print(f'x: {x} res: {res} logp_x: {logp_x} inside: {self.p_inside} loginside: {self.logp_inside} floor: {self.floor} ceil: {self.ceiling}')
         return res
 
     def cdf(self, x):
@@ -63,13 +61,13 @@ class TruncatedLogisticMixture(Mixture, Optimizable):
     def from_params(cls, fixed_params, opt_params, traceable=True):
         floor = fixed_params["floor"]
         ceiling = fixed_params["ceiling"]
+        # Hardcode -2 and 3 for now since importing causes an import cycle
         loc_floor = floor + (ceiling - floor) * -2
         loc_ceiling = floor + (ceiling - floor) * 3
         structured_params = opt_params.reshape((-1, 3))
         locs = loc_floor + scipy.special.expit(structured_params[:, 0]) * (
             loc_ceiling - loc_floor
         )
-        # print(f'plocs: {locs}')
         scales = np.abs(structured_params[:, 1])
         probs = list(nn.softmax(structured_params[:, 2]))
         component_dists = [Logistic(l, s) for (l, s) in zip(locs, scales)]

--- a/ergo/distributions/truncated_logistic_mixture.py
+++ b/ergo/distributions/truncated_logistic_mixture.py
@@ -61,9 +61,9 @@ class TruncatedLogisticMixture(Mixture, Optimizable):
     def from_params(cls, fixed_params, opt_params, traceable=True):
         floor = fixed_params["floor"]
         ceiling = fixed_params["ceiling"]
-        # Hardcode -2 and 3 for now since importing causes an import cycle
-        loc_floor = floor + (ceiling - floor) * -2
-        loc_ceiling = floor + (ceiling - floor) * 3
+        # Allow logistic center to exceed the range by 50%
+        loc_floor = floor + (ceiling - floor) * -0.5
+        loc_ceiling = floor + (ceiling - floor) * 1.5
         structured_params = opt_params.reshape((-1, 3))
         locs = loc_floor + scipy.special.expit(structured_params[:, 0]) * (
             loc_ceiling - loc_floor
@@ -84,7 +84,7 @@ class TruncatedLogisticMixture(Mixture, Optimizable):
         """
         num_components = fixed_params["num_components"]
         scale_multiplier = 0.2
-        loc_multiplier = 1
+        loc_multiplier = 5
         locs = (onp.random.rand(num_components) - 0.5) * loc_multiplier
         scales = onp.random.rand(num_components) * scale_multiplier
         weights = onp.full(num_components, -num_components)

--- a/ergo/platforms/metaculus/question/constants.py
+++ b/ergo/platforms/metaculus/question/constants.py
@@ -2,6 +2,10 @@
 # https://pandemic.metaculus.com/questions/3920/what-will-the-cbo-estimate-to-be-the-cost-of-the-emergency-telework-act-s3561/
 max_loc = 3
 
+# Min loc set based on API response to prediction on
+# https://www.metaculus.com/questions/3992/
+min_loc = -2
+
 # Max scale of 10 set based on API response to prediction on
 # https://pandemic.metaculus.com/questions/3920/what-will-the-cbo-estimate-to-be-the-cost-of-the-emergency-telework-act-s3561/
 min_scale = 0.01

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -22,7 +22,7 @@ def test_logpdf(logistic_mixture):
 )
 def test_fit_mixture_small(LogisticMixtureClass):
     mixture = LogisticMixtureClass.from_samples(
-        np.array([0.1, 0.2, 0.8, 0.9]), {"num_components": 2, "floor": -3, "ceiling": 3}
+        np.array([0.1, 0.2, 0.8, 0.9]), {"num_components": 2, "floor": 0, "ceiling": 1}
     )
     for prob in mixture.probs:
         assert prob == pytest.approx(0.5, 0.1)


### PR DESCRIPTION
Also restrict variance to positive values.

Metaculus allows locations for a somewhat wider range than this. If this matters, we'd need to separate truncation floor/ceiling and distribution location floor/ceiling.

Needed to close https://github.com/oughtinc/elicit/issues/151