### PR TITLE
Export scales as dicts 

### DIFF
--- a/ergo/scale.py
+++ b/ergo/scale.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from datetime import date, datetime, timedelta
 from typing import TypeVar, Union
 
@@ -52,8 +52,9 @@ class Scale:
         return (Scale, (self.low, self.high))
 
     def export(self):
-        cls, params = self.destructure()
-        return (cls.__name__, params)
+        export_dict = asdict(self)
+        export_dict["class"] = type(self).__name__
+        return export_dict
 
 
 ScaleClass = TypeVar("ScaleClass", bound=Scale)
@@ -144,10 +145,15 @@ class TimeScale(Scale):
         return (TimeScale, (self.low, self.high, self.time_unit))
 
 
-def scale_factory(class_name, params):
-    if type(class_name) == str:
-        if class_name == "Scale":
-            return Scale(*params)
-        elif class_name == "LogScale":
-            return LogScale(*params)
-    raise TypeError("cannot reconstruct Scale")
+def scale_factory(scale_dict):
+    scale_class = scale_dict["class"]
+    low = scale_dict["low"]
+    high = scale_dict["high"]
+
+    if scale_class == "Scale":
+        return Scale(low, high)
+    if scale_class == "LogScale":
+        return LogScale(low, high, scale_dict["log_base"])
+    raise NotImplementedError(
+        f"reconstructing scales of class {scale_class} is not implemented."
+    )

--- a/tests/test_scales.py
+++ b/tests/test_scales.py
@@ -1,4 +1,4 @@
-from ergo.scale import LogScale, Scale
+from ergo.scale import LogScale, Scale, scale_factory
 
 
 def test_serialization():
@@ -6,3 +6,15 @@ def test_serialization():
     assert hash(Scale(0, 100)) != hash(Scale(100, 200))
     assert hash(LogScale(0, 100, 1)) != hash(Scale(0, 100))
     assert hash(LogScale(0, 100, 10)) != hash(LogScale(0, 100, 10))
+
+
+def test_export_import():
+    log_scale = LogScale(low=-1, high=1, log_base=2)
+    log_scale_export = log_scale.export()
+    assert log_scale_export["width"] == 2
+    assert log_scale_export["class"] == "LogScale"
+
+    assert (scale_factory(log_scale.export())) == log_scale
+
+    linear_scale = Scale(low=1, high=10000)
+    assert (scale_factory(linear_scale.export())) == linear_scale


### PR DESCRIPTION
(so that, e.g., they can easily be used on the frontend), and test

Used in this Elicit PR: https://github.com/oughtinc/elicit/pull/183

I'd say that both should be merged at the same time