### PR TITLE
Improve PPF for mixture of truncated dists

### DIFF
--- a/ergo/__init__.py
+++ b/ergo/__init__.py
@@ -16,6 +16,7 @@ from .distributions import (
     LogisticMixture,
     LogNormalFromInterval,
     NormalFromInterval,
+    Truncate,
     bernoulli,
     beta,
     beta_from_hits,

--- a/ergo/distributions/histogram.py
+++ b/ergo/distributions/histogram.py
@@ -187,7 +187,7 @@ class HistogramDist(Distribution, Optimizable):
         self, true_scale=True, verbose=False,
     ):
 
-        xs, ps = self.to_lists(true_scale=True, verbose=False)
+        xs, ps = self.to_lists(true_scale=True, verbose=verbose)
 
         return [
             {"x": float(x), "density": float(density)} for x, density in zip(xs, ps)

--- a/ergo/distributions/logistic.py
+++ b/ergo/distributions/logistic.py
@@ -69,7 +69,9 @@ class Logistic(Distribution):
         return scipy.stats.logistic.cdf(y)
 
     def ppf(self, q):
-        raise NotImplementedError
+        return self.scale.denormalize_point(
+            oscipy.stats.logistic(loc=self.loc, scale=self.s).ppf(q)
+        )
 
     def sample(self):
         return self.scale.denormalize_point(

--- a/ergo/distributions/truncate.py
+++ b/ergo/distributions/truncate.py
@@ -1,8 +1,6 @@
 from dataclasses import dataclass
 
-from jax import scipy
 import jax.numpy as np
-import scipy as oscipy
 
 from ergo.scale import Scale
 
@@ -49,12 +47,7 @@ class Truncate(Distribution):
         """
         Percent point function (inverse of cdf) at q.
         """
-        return oscipy.optimize.bisect(
-            lambda x: self.cdf(x) - q,
-            self.scale.low - self.scale.width,
-            self.scale.high + self.scale.width,
-            maxiter=1000,
-        )
+        return self.base_dist.ppf(self.p_below + q * self.p_inside)
 
     def sample(self):
         success = False

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -1,12 +1,14 @@
 import jax.numpy as np
 import numpy as onp
 import pytest
-import scipy.stats
+import scipy
 
-from ergo import Logistic, LogisticMixture
+from ergo import Logistic, LogisticMixture, Truncate
 from ergo.conditions import HistogramCondition
 from ergo.scale import LogScale, Scale
 from tests.conftest import scales_to_test
+
+# import scipy.stats
 
 
 @pytest.mark.parametrize("xscale", scales_to_test)
@@ -39,7 +41,90 @@ def test_cdf(xscale: Scale):
 # TODO test truncated Logistic better in this file
 
 
-# @pytest.mark.slow
+@pytest.mark.look
+@pytest.mark.parametrize("xscale", scales_to_test)
+def test_trucated_ppf(xscale: Scale):
+    normed_test_loc = 0.5
+    normed_test_s = 0.1
+    test_loc = xscale.denormalize_point(normed_test_loc)
+    test_s = normed_test_s * xscale.width
+
+    normed_baseline_dist = scipy.stats.logistic(normed_test_loc, normed_test_s)
+
+    def ppf_through_cdf(dist, q):
+        return scipy.optimize.bisect(
+            lambda x: dist.cdf(x) - q, dist.ppf(0.0001), dist.ppf(0.9999), maxiter=1000
+        )
+
+    # No bounds
+    dist_w_no_bounds = Truncate(Logistic(loc=test_loc, s=test_s, scale=xscale))
+
+    for x in np.linspace(0.01, 0.99, 8):
+        assert dist_w_no_bounds.ppf(x) == pytest.approx(
+            xscale.denormalize_point(normed_baseline_dist.ppf(x))
+        )
+
+    # Floor
+    dist_w_floor = Truncate(
+        Logistic(loc=test_loc, s=test_s, scale=xscale),
+        floor=xscale.denormalize_point(0.5),
+    )
+
+    mix_w_floor = LogisticMixture(
+        components=[
+            Truncate(  # type: ignore
+                Logistic(test_loc, s=test_s, scale=xscale),
+                floor=xscale.denormalize_point(0.5),
+            )
+        ],
+        probs=[1.0],
+    )
+
+    for x in np.linspace(0.01, 0.99, 8):
+        assert dist_w_floor.ppf(x) == mix_w_floor.ppf(x)
+
+    # Ceiling
+    dist_w_ceiling = Truncate(
+        Logistic(loc=test_loc, s=test_s, scale=xscale),
+        ceiling=xscale.denormalize_point(0.8),
+    )
+
+    mix_w_ceiling = LogisticMixture(
+        components=[
+            Truncate(  # type: ignore
+                Logistic(test_loc, s=test_s, scale=xscale),
+                ceiling=xscale.denormalize_point(0.8),
+            )
+        ],
+        probs=[1.0],
+    )
+
+    for x in np.linspace(0.01, 0.99, 8):
+        dist_w_ceiling.ppf(x) == mix_w_ceiling.ppf(x)
+
+    # Floor and Ceiling
+
+    dist_w_floor_and_ceiling = Truncate(
+        Logistic(loc=test_loc, s=test_s, scale=xscale),
+        floor=xscale.denormalize_point(0.2),
+        ceiling=xscale.denormalize_point(0.8),
+    )
+
+    mix_w_floor_and_ceiling = LogisticMixture(
+        components=[
+            Truncate(  # type: ignore
+                Logistic(test_loc, s=test_s, scale=xscale),
+                floor=xscale.denormalize_point(0.2),
+                ceiling=xscale.denormalize_point(0.8),
+            )
+        ],
+        probs=[1.0],
+    )
+
+    for x in np.linspace(0.01, 0.99, 8):
+        dist_w_floor_and_ceiling.ppf(x) == mix_w_floor_and_ceiling.ppf(x)
+
+
 @pytest.mark.parametrize("xscale", scales_to_test)
 def test_pdf(xscale: Scale):
     normed_test_loc = 0.8

--- a/tests/test_logistic.py
+++ b/tests/test_logistic.py
@@ -8,8 +8,6 @@ from ergo.conditions import HistogramCondition
 from ergo.scale import LogScale, Scale
 from tests.conftest import scales_to_test
 
-# import scipy.stats
-
 
 @pytest.mark.parametrize("xscale", scales_to_test)
 def test_cdf(xscale: Scale):
@@ -61,7 +59,7 @@ def test_trucated_ppf(xscale: Scale):
 
     for x in np.linspace(0.01, 0.99, 8):
         assert dist_w_no_bounds.ppf(x) == pytest.approx(
-            xscale.denormalize_point(normed_baseline_dist.ppf(x))
+            xscale.denormalize_point(normed_baseline_dist.ppf(x)), rel=0.001
         )
 
     # Floor
@@ -81,7 +79,10 @@ def test_trucated_ppf(xscale: Scale):
     )
 
     for x in np.linspace(0.01, 0.99, 8):
-        assert dist_w_floor.ppf(x) == mix_w_floor.ppf(x)
+        assert dist_w_floor.ppf(x) == pytest.approx(mix_w_floor.ppf(x), rel=0.001)
+        assert dist_w_floor.ppf(x) == pytest.approx(
+            ppf_through_cdf(dist_w_floor, x), rel=0.001
+        )
 
     # Ceiling
     dist_w_ceiling = Truncate(
@@ -100,7 +101,10 @@ def test_trucated_ppf(xscale: Scale):
     )
 
     for x in np.linspace(0.01, 0.99, 8):
-        dist_w_ceiling.ppf(x) == mix_w_ceiling.ppf(x)
+        assert dist_w_ceiling.ppf(x) == pytest.approx(mix_w_ceiling.ppf(x), rel=0.001)
+        assert dist_w_ceiling.ppf(x) == pytest.approx(
+            ppf_through_cdf(dist_w_ceiling, x), rel=0.001
+        )
 
     # Floor and Ceiling
 
@@ -122,7 +126,12 @@ def test_trucated_ppf(xscale: Scale):
     )
 
     for x in np.linspace(0.01, 0.99, 8):
-        dist_w_floor_and_ceiling.ppf(x) == mix_w_floor_and_ceiling.ppf(x)
+        assert dist_w_floor_and_ceiling.ppf(x) == pytest.approx(
+            mix_w_floor_and_ceiling.ppf(x), rel=0.001
+        )
+        assert dist_w_floor_and_ceiling.ppf(x) == pytest.approx(
+            ppf_through_cdf(dist_w_floor_and_ceiling, x), rel=0.001
+        )
 
 
 @pytest.mark.parametrize("xscale", scales_to_test)


### PR DESCRIPTION
This PR fixes some ppf issues with the new truncated dists and mixture of truncated dists. I tested 14 random log questions with `test_submission` and all of them computed successfully. 

Specifically this PR:
1. Updates the logistic_mixture ppf to get the starting bounds for the optimization call from the ppfs of the components. To my knowledge, there is not a principled way to get the bounds from the mixture level
2. Updated the Truncated ppf method with an analytic solution. This should be faster and less error-prone. This required re-adding the Logistic ppf method. 
3. Added tests of the new ppf methods in each of the possible bound conditions for all available scales
