### PR TITLE
Move latest_community_percentiles 

### DIFF
--- a/ergo/platforms/metaculus/question/continuous.py
+++ b/ergo/platforms/metaculus/question/continuous.py
@@ -101,6 +101,15 @@ class ContinuousQuestion(MetaculusQuestion):
     def plot_title(self):
         return "\n".join(textwrap.wrap(self.name or self.data["title"], 60))  # type: ignore
 
+    @property
+    def latest_community_percentiles(self):
+        """
+        :return: Some percentiles for the metaculus commununity's latest rough
+            prediction. `prediction_histogram` returns a more fine-grained
+            histogram of the community prediction
+        """
+        return self.prediction_timeseries[-1]["community_prediction"]
+
     def prepare_logistic(self, normalized_dist: dist.Logistic) -> dist.Logistic:
         """
         Transform a single logistic distribution by clipping the

--- a/ergo/platforms/metaculus/question/question.py
+++ b/ergo/platforms/metaculus/question/question.py
@@ -77,15 +77,6 @@ class MetaculusQuestion:
     def __str__(self):
         return repr(self)
 
-    @property
-    def latest_community_percentiles(self):
-        """
-        :return: Some percentiles for the metaculus commununity's latest rough
-            prediction. `prediction_histogram` returns a more fine-grained
-            histogram of the community prediction
-        """
-        return self.prediction_timeseries[-1]["community_prediction"]
-
     def __getattr__(self, name):
         """
         If an attribute isn't directly on the class, check whether it's in the


### PR DESCRIPTION
from MetaculusQuestion to ContinuosuQuestion.

for ContinuousQuestions, this indeed gives the percentiles as desired. But for BinaryQuestions, the community_prediction is a float (rather than percentiles), so this returns a float

I could have added some replacement function to BinaryQuestion, but decided not to for now because it's unclear what we'd want. Binary question prediction_timeseries have the following structure:

```
{
    "t": 1592276813.6254,
    "distribution": {
        "avg": 0.81148,
        "num": 88,
        "var": 0.03514
    },
    "num_predictions": 124,
    "community_prediction": 0.87
}
```

We might want to return the `distribution` somehow, or maybe not, but seems unclear at the moment