### PR TITLE
Hist regression tests

### DIFF
--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -347,6 +347,22 @@ def test_histogram_fit(histogram):
         assert dist.pdf(original_x) == pytest.approx(original_density, abs=0.05)
 
 
+def test_histogram_fit_regression_p_in_range():
+    """
+    Regression test for a bug where:
+    1. < 100% of p is in the entire range, for a closed-bound question
+    2. the p is smashed up against the edges of the range
+    rather than distributed evenly over the whole range
+
+    e.g. see https://elicit.ought.org/builder/Mib4yBPDE
+    """
+    histogram_dist = HistogramDist.from_conditions(
+        conditions=[IntervalCondition(min=0, max=1, p=0.5)]
+    )
+
+    assert histogram_dist.cdf(1) == 1
+
+
 def compare_runtimes():
     from tests.conftest import make_histogram
 

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -371,7 +371,7 @@ def test_histogram_fit_regression_p_in_range():
 def test_fit_hist_regression_1():
     """
     Regression test for bug: "This custom question has a weird histogram - why?"
-    
+
     see https://elicit.ought.org/builder/gflpsSBAb
 
     for more on the bug, see

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -356,6 +356,9 @@ def test_histogram_fit_regression_p_in_range():
     rather than distributed evenly over the whole range
 
     e.g. see https://elicit.ought.org/builder/Mib4yBPDE
+
+    For more on the bug, see
+    https://docs.google.com/document/d/1CFklTKtbKzXi6-lRaEsX4ZiY3Yzpbfdg7i2j1NvKP34/edit#heading=h.lypz52bknpyq
     """
     histogram_dist = HistogramDist.from_conditions(
         conditions=[IntervalCondition(min=0, max=1, p=0.5)]
@@ -368,7 +371,11 @@ def test_histogram_fit_regression_p_in_range():
 def test_fit_hist_regression_1():
     """
     Regression test for bug: "This custom question has a weird histogram - why?"
-    https://elicit.ought.org/builder/gflpsSBAb
+    
+    see https://elicit.ought.org/builder/gflpsSBAb
+
+    for more on the bug, see
+    https://docs.google.com/document/d/1CFklTKtbKzXi6-lRaEsX4ZiY3Yzpbfdg7i2j1NvKP34/edit#heading=h.ph1huakxn33f
     """
     conditions = [
         IntervalCondition(p=0.25, max=2.0),


### PR DESCRIPTION
Add regression tests for two bugs

The bugs are described in the test docstrings

These tests currently fail, so they're marked with xfail

We hope that the tests will pass once we switch to PointDensity

I think it makes sense to merge these now to give us some things to work towards for PointDensity