### PR TITLE
Generate consistent UTC timestamps

### DIFF
--- a/ergo/platforms/metaculus/question/lineardate.py
+++ b/ergo/platforms/metaculus/question/lineardate.py
@@ -36,7 +36,10 @@ class LinearDateQuestion(ContinuousQuestion):
         return scale_x_datetime(limits=(xmin, xmax))
 
     def date_to_timestamp(self, date: str):
-        return datetime.datetime.strptime(date, "%Y-%m-%d").timestamp()
+        dt = datetime.datetime.strptime(date, "%Y-%m-%d")
+        # To obtain UTC timestamp from datetime, used method described here:
+        # https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp
+        return dt.replace(tzinfo=datetime.timezone.utc).timestamp()
 
     # TODO enforce return type date/datetime
     def sample_community(self):

--- a/ergo/platforms/metaculus/question/lineardate.py
+++ b/ergo/platforms/metaculus/question/lineardate.py
@@ -36,6 +36,13 @@ class LinearDateQuestion(ContinuousQuestion):
         return scale_x_datetime(limits=(xmin, xmax))
 
     def date_to_timestamp(self, date: str):
+        """
+        Turn a date string in %Y-%m-%d format into a timestamp. Metaculus
+        uses this format for dates when specifying the range of a date question.
+        We're assuming Metaculus is interpreting these date strings as UTC.
+
+        :return: A Unix timestamp
+        """
         dt = datetime.datetime.strptime(date, "%Y-%m-%d")
         # To obtain UTC timestamp from datetime, used method described here:
         # https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp


### PR DESCRIPTION
Ergo currently uses the local timezone to turn a datetime (like the one obtained from "2020-06-30" via strptime) into a timestamp. This means it can assign different timestamps to the same Metaculus questions, depending on the timezone Ergo is operating in.

This PR changes Ergo to alway use UTC to generate the timestamp. 

This will partially fix the following Elicit issue:

Fixes OUG-209