### PR TITLE
Point Density isnt fully precompiled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+## [Unreleased]
+
+
+## [0.1.1] - 2020-07-15
+
+### Changed
+
+- All arguments passed to Scales are now `float`s and all Scale fields are assumed to be `float`s
+
+
+
+## [0.1.0] - 2020-07-12
+
+### Added
+
+- `PointDensity()` distribution. We now primarily operate on point densities located in the center of what used to be the bins in our histogram.
+- "denorm_xs_only" option on PointDensity egress methods. This returns normalized probability densities but on a denormalized x-axis, as Metaculus displays.
+- support for LogScale and Metaculus/Elicit LogScale questions
+
+### Changed
+
+- We operate on 200 point densities at the center of bins evenly spaced from 0 to 1 on a normalized scale. If we are passed in anything besides this in from_pairs we interpolate to get 200 points placed in this manner.
+- We always operate on normalized points and normalized densities internally, using the `normed_xs` and `normed_densities` fields respectively. We denormalize the density before returning in PDF.
+- PointDensity.cdf(x) returns the cdf up to x (not the bin before x, as previously)
+
+### Removed
+- the `Histrogram()` distribution
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 
-## [0.1.1] - 2020-07-15
+## [0.8.4] - 2020-07-15
 
 ### Changed
 
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 
 
-## [0.1.0] - 2020-07-12
+## [0.8.3] - 2020-07-12
 
 ### Added
 

--- a/ergo/__init__.py
+++ b/ergo/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.8.3"
+__version__ = "0.8.4"
 
 import ergo.conditions
 import ergo.distributions

--- a/ergo/conditions/crossentropy.py
+++ b/ergo/conditions/crossentropy.py
@@ -37,6 +37,9 @@ class CrossEntropyCondition(condition.Condition):
     def __str__(self):
         return "Minimize the cross-entropy of the two distributions"
 
+    def __repr__(self):
+        return f"CrossEntropyCondition(p_dist={self.p_dist.normed_xs.size}, weight={self.weight})"
+
 
 class PartialCrossEntropyCondition(condition.Condition):
     """

--- a/ergo/conditions/smoothness.py
+++ b/ergo/conditions/smoothness.py
@@ -23,3 +23,6 @@ class SmoothnessCondition(condition.Condition):
 
     def __str__(self):
         return "Minimize rough edges in the distribution"
+
+    def __repr__(self):
+        return f"SmoothnessCondition(weight={self.weight})"

--- a/ergo/distributions/logistic_mixture.py
+++ b/ergo/distributions/logistic_mixture.py
@@ -119,7 +119,7 @@ class LogisticMixture(Distribution, Optimizable):
         cls, fixed_params, opt_params, scale=None, traceable=True
     ):  # FIXME: traceable; why sometimes no Scale?
         if not scale:
-            scale = Scale(0, 1)
+            scale = Scale(0.0, 1.0)
         floor = fixed_params.get("floor", -np.inf)
         ceiling = fixed_params.get("ceiling", np.inf)
         # Allow logistic center to exceed the range by 20%

--- a/ergo/distributions/optimizable.py
+++ b/ergo/distributions/optimizable.py
@@ -88,7 +88,7 @@ class Optimizable(ABC):
             fixed_params = {}
 
         if scale is None:
-            scale = Scale(0, 1)
+            scale = Scale(0.0, 1.0)
 
         fixed_params = cls.normalize_fixed_params(fixed_params, scale)
         normalized_conditions = [condition.normalize(scale) for condition in conditions]

--- a/ergo/distributions/point_density.py
+++ b/ergo/distributions/point_density.py
@@ -117,7 +117,10 @@ class PointDensity(Distribution, Optimizable):
 
     def normalize(self):
         return PointDensity(
-            self.normed_xs, self.normed_densities, scale=Scale(0, 1), normalized=True
+            self.normed_xs,
+            self.normed_densities,
+            scale=Scale(0.0, 1.0),
+            normalized=True,
         )
 
     def denormalize(self, scale: Scale):
@@ -190,7 +193,9 @@ class PointDensity(Distribution, Optimizable):
         )
 
     @classmethod
-    def from_params(cls, fixed_params, opt_params, scale=Scale(0, 1), traceable=True):
+    def from_params(cls, fixed_params, opt_params, scale=None, traceable=True):
+        if scale is None:
+            scale = Scale(0.0, 1.0)
         xs = fixed_params["xs"]
 
         densities = nn.softmax(opt_params) * opt_params.size

--- a/ergo/platforms/metaculus/question/continuous.py
+++ b/ergo/platforms/metaculus/question/continuous.py
@@ -379,9 +379,9 @@ class ContinuousQuestion(MetaculusQuestion):
         floor, ceiling = None, None
         possibilities = self.possibilities
         if possibilities.get("low") != "tail":
-            floor = self.scale.low
+            floor = float(self.scale.low)
         if possibilities.get("high") != "tail":
-            ceiling = self.scale.high
+            ceiling = float(self.scale.high)
         return Bounds(floor=floor, ceiling=ceiling)
 
     def get_logistic_from_json(self, logistic_json: Dict) -> dist.Logistic:

--- a/ergo/platforms/metaculus/question/linear.py
+++ b/ergo/platforms/metaculus/question/linear.py
@@ -19,7 +19,9 @@ class LinearQuestion(ContinuousQuestion):
         self, id: int, metaculus: Any, data: Dict, name=None,
     ):
         super().__init__(id, metaculus, data, name)
-        self.scale = Scale(self.question_range["min"], self.question_range["max"])
+        self.scale = Scale(
+            float(self.question_range["min"]), float(self.question_range["max"])
+        )
 
     # TODO: also return low and high on the true scale,
     # and use those somehow in logistic.py

--- a/ergo/platforms/metaculus/question/log.py
+++ b/ergo/platforms/metaculus/question/log.py
@@ -18,9 +18,9 @@ class LogQuestion(ContinuousQuestion):
     ):
         super().__init__(id, metaculus, data, name)
         self.scale = LogScale(
-            self.question_range["min"],
-            self.question_range["max"],
-            self.possibilities["scale"]["deriv_ratio"],
+            float(self.question_range["min"]),
+            float(self.question_range["max"]),
+            float(self.possibilities["scale"]["deriv_ratio"]),
         )
 
     def _scale_x(self, xmin: float = None, xmax: float = None):

--- a/ergo/scale.py
+++ b/ergo/scale.py
@@ -194,13 +194,13 @@ class TimeScale(Scale):
 
 def scale_factory(scale_dict):
     scale_class = scale_dict["class"]
-    low = scale_dict["low"]
-    high = scale_dict["high"]
+    low = float(scale_dict["low"])
+    high = float(scale_dict["high"])
 
     if scale_class == "Scale":
         return Scale(low, high)
     if scale_class == "LogScale":
-        return LogScale(low, high, scale_dict["log_base"])
+        return LogScale(low, high, float(scale_dict["log_base"]))
     if scale_class == "TimeScale":
         return TimeScale(low, high)
     raise NotImplementedError(

--- a/ergo/scale.py
+++ b/ergo/scale.py
@@ -82,9 +82,6 @@ ScaleClass = TypeVar("ScaleClass", bound=Scale)
 class LogScale(Scale):
     log_base: float
 
-    def __post_init__(self):
-        self.width = self.high - self.low
-
     def __hash__(self):
         return super().__hash__()
 
@@ -175,11 +172,6 @@ class LogScale(Scale):
 
 @dataclass
 class TimeScale(Scale):
-    def __init__(self, low, high):
-        self.low = low
-        self.high = high
-        self.width = self.high - self.low
-
     def __repr__(self):
         return (
             f"TimeScale(low={self.timestamp_to_str(self.low)}, "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ergo"
-version = "0.8.3"
+version = "0.8.4"
 description = ""
 authors = ["Ought <team@ought.org>"]
 


### PR DESCRIPTION
This PR has some small changes to ensure that scales always have float-valued fields. 

I've tested elicit with these updates looking at:
All combinations of scale_type and question_type
with one of each kind of bound condition (bounds not crossed with scale_type and question_type)
