### PR TITLE
Prevent errors due to computing log of probability 0

### DIFF
--- a/ergo/distributions/point_density.py
+++ b/ergo/distributions/point_density.py
@@ -55,7 +55,8 @@ class PointDensity(Distribution, Optimizable):
             self.cumulative_normed_ps = init_np.append(
                 init_np.array([0]), init_np.cumsum(self.bin_probs)
             )
-        self.normed_log_densities = init_np.log(self.normed_densities)
+
+        self.normed_log_densities = init_np.log(self.normed_densities + 1e-15)
 
     # Distribution
 
@@ -199,6 +200,7 @@ class PointDensity(Distribution, Optimizable):
         xs = fixed_params["xs"]
 
         densities = nn.softmax(opt_params) * opt_params.size
+
         return cls(
             xs=xs, densities=densities, scale=scale, normalized=True, traceable=True
         )
@@ -268,11 +270,11 @@ class PointDensity(Distribution, Optimizable):
     # Condition Methods
 
     def entropy(self):
-        return -np.dot(self.bin_probs, np.log(self.bin_probs))
+        return -np.dot(self.bin_probs, np.log(self.bin_probs + 1e-15))
 
     def cross_entropy(self, q_dist):
         # We assume that the distributions are on the same scale!
-        return -np.dot(self.bin_probs, np.log(q_dist.bin_probs))
+        return -np.dot(self.bin_probs, np.log(q_dist.bin_probs + 1e-15))
 
     def mean(self):
         return np.dot(self.scale.denormalize_points(self.normed_xs), self.bin_probs)

--- a/ergo/distributions/point_density.py
+++ b/ergo/distributions/point_density.py
@@ -81,7 +81,7 @@ class PointDensity(Distribution, Optimizable):
         )
 
     def logpdf(self, x):
-        return np.log(self.pdf(x))
+        return np.log(self.pdf(x) + 1e-15)
 
     def cdf(self, x):
         """

--- a/ergo/distributions/point_density.py
+++ b/ergo/distributions/point_density.py
@@ -6,6 +6,7 @@ import numpy as onp
 from scipy.interpolate import interp1d
 
 from ergo.scale import Scale
+from ergo.utils import safe_log
 
 from . import constants
 from .distribution import Distribution
@@ -15,7 +16,7 @@ from .optimizable import Optimizable
 @dataclass
 class PointDensity(Distribution, Optimizable):
     """
-    A distribution specified through a number of density points.
+    a distribution specified through a number of density points.
     """
 
     normed_xs: np.DeviceArray
@@ -56,7 +57,7 @@ class PointDensity(Distribution, Optimizable):
                 init_np.array([0]), init_np.cumsum(self.bin_probs)
             )
 
-        self.normed_log_densities = init_np.log(self.normed_densities + 1e-15)
+        self.normed_log_densities = safe_log(self.normed_densities)
 
     # Distribution
 
@@ -81,7 +82,7 @@ class PointDensity(Distribution, Optimizable):
         )
 
     def logpdf(self, x):
-        return np.log(self.pdf(x) + 1e-15)
+        return safe_log(self.pdf(x))
 
     def cdf(self, x):
         """
@@ -270,11 +271,11 @@ class PointDensity(Distribution, Optimizable):
     # Condition Methods
 
     def entropy(self):
-        return -np.dot(self.bin_probs, np.log(self.bin_probs + 1e-15))
+        return -np.dot(self.bin_probs, safe_log(self.bin_probs))
 
     def cross_entropy(self, q_dist):
         # We assume that the distributions are on the same scale!
-        return -np.dot(self.bin_probs, np.log(q_dist.bin_probs + 1e-15))
+        return -np.dot(self.bin_probs, safe_log(q_dist.bin_probs))
 
     def mean(self):
         return np.dot(self.scale.denormalize_points(self.normed_xs), self.bin_probs)

--- a/ergo/utils.py
+++ b/ergo/utils.py
@@ -76,5 +76,5 @@ def trapz(y, x=None, dx=1.0):
     return 0.5 * (dx * (y[..., 1:] + y[..., :-1])).sum(-1)
 
 
-def safe_log(x, constant=1e-15):
+def safe_log(x, constant=1e-37):
     return np.log(x + constant)

--- a/ergo/utils.py
+++ b/ergo/utils.py
@@ -74,3 +74,7 @@ def trapz(y, x=None, dx=1.0):
     if x is not None:
         dx = np.diff(x)
     return 0.5 * (dx * (y[..., 1:] + y[..., :-1])).sum(-1)
+
+
+def safe_log(x, constant=1e-15):
+    return np.log(x + constant)


### PR DESCRIPTION
This PR has a simple fix for the situation where the density of a point/mass of a bin is 0. It adds a minuscule amount to the density prior when it is passed to a log function. 

An alternative would be to simply add this small amount to density proper, however I thought that there is end-user utility in being able to specify true 0 bins (trade-off being that there is a minuscule disconnect from the actual density and log density) 
