### PR TITLE
Update entropy calcs to take into account different bin_widths

### DIFF
--- a/ergo/distributions/point_density.py
+++ b/ergo/distributions/point_density.py
@@ -68,6 +68,10 @@ class PointDensity(Distribution, Optimizable):
     def true_grid(self):
         return self.scale.denormalize_points(constants.grid)
 
+    @cached_property
+    def true_densities(self):
+        return self.scale.denormalize_densities(self.true_xs, self.normed_densities)
+
     # Distribution
 
     def pdf(self, x):
@@ -286,11 +290,11 @@ class PointDensity(Distribution, Optimizable):
     # Condition Methods
 
     def entropy(self):
-        return -np.dot(self.bin_probs, safe_log(self.bin_probs))
+        return -np.dot(self.bin_probs, safe_log(self.true_densities))
 
     def cross_entropy(self, q_dist):
         # We assume that the distributions are on the same scale!
-        return -np.dot(self.bin_probs, safe_log(q_dist.bin_probs))
+        return -np.sum(self.bin_probs * safe_log(q_dist.true_densities))
 
     def mean(self):
         return np.dot(self.true_xs, self.bin_probs)


### PR DESCRIPTION
(Note I haven't verified this section sufficiently yet)
Armed with our new understanding, we can now update our entropy function. This function takes into account the width of the true-scale bins such that less-entropy bin_probs for larger bins will have a bigger affect on the distribution entropy than smaller bins. This will finally give us what we expect if we assume that the entropy function has access to the true-scale densities, which it doesn't in our current fitting scheme. E.g. the max-entropy distribution will be uniform in true-space.

$H(X) = \sum_{k=1}^{n} p_k log(p_k/w_k)$
where `p_k` is the probability of bin `k`, and `w_k` is the width of bin `k`. Note that probability/bin_width is the average bin density so in our code we can simply write:

`-np.dot(self.bin_probs, safe_log(self.true_densities))`
  
It is the same calculation scipy rv_histogram [uses](https://github.com/scipy/scipy/blob/01d8bfb6f239df4ce70c799b9b485b53733c9911/scipy/stats/_continuous_distns.py#L8683)
and also described [here](https://warwick.ac.uk/fac/soc/economics/staff/academic/wallis/publications/entropy.pdf
)
