### PR TITLE
Add smoothing term based on change in slope (second derivative)

### DIFF
--- a/ergo/conditions/smoothness.py
+++ b/ergo/conditions/smoothness.py
@@ -5,7 +5,10 @@ from . import condition
 
 class SmoothnessCondition(condition.Condition):
     def loss(self, dist) -> float:
-        return self.weight * np.sum(np.square(np.diff(dist.normed_log_densities, n=2)))
+        return self.weight * (
+            np.sum(np.square(np.diff(dist.normed_log_densities, n=2))) / 2 + 
+            np.sum(np.square(np.diff(dist.normed_log_densities, n=1))) / 100
+        )
 
     def destructure(self):
         return ((SmoothnessCondition,), (self.weight,))

--- a/ergo/conditions/smoothness.py
+++ b/ergo/conditions/smoothness.py
@@ -1,7 +1,5 @@
 import jax.numpy as np
 
-from ergo.utils import shift
-
 from . import condition
 
 

--- a/ergo/conditions/smoothness.py
+++ b/ergo/conditions/smoothness.py
@@ -7,16 +7,7 @@ from . import condition
 
 class SmoothnessCondition(condition.Condition):
     def loss(self, dist) -> float:
-        window_size = 5
-        squared_distance = 0.0
-        for i in range(1, window_size + 1):
-            squared_distance += (1 / i ** 2) * np.sum(
-                np.square(
-                    dist.normed_log_densities
-                    - shift(dist.normed_log_densities, i, dist.normed_log_densities[0])
-                )
-            )
-        return self.weight * squared_distance / dist.normed_log_densities.size
+        return self.weight * np.sum(np.square(np.diff(dist.normed_log_densities, n=2)))
 
     def destructure(self):
         return ((SmoothnessCondition,), (self.weight,))

--- a/ergo/conditions/smoothness.py
+++ b/ergo/conditions/smoothness.py
@@ -6,8 +6,8 @@ from . import condition
 class SmoothnessCondition(condition.Condition):
     def loss(self, dist) -> float:
         return self.weight * (
-            np.sum(np.square(np.diff(dist.normed_log_densities, n=2))) / 2 + 
-            np.sum(np.square(np.diff(dist.normed_log_densities, n=1))) / 100
+            np.sum(np.square(np.diff(dist.normed_log_densities, n=2))) / 2
+            + np.sum(np.square(np.diff(dist.normed_log_densities, n=1))) / 100
         )
 
     def destructure(self):


### PR DESCRIPTION
In addition to first derivative, to avoid notches. More info at https://docs.google.com/document/d/1sawgEzYF-xrCk8Lnc3PIZde_Jg6VQ4R1-kK5hKvtgdo/edit#heading=h.rhxxklbrss0w. Analysis of effects at https://docs.google.com/document/d/1sawgEzYF-xrCk8Lnc3PIZde_Jg6VQ4R1-kK5hKvtgdo/edit#heading=h.pyyxu7uwlefu

TODO: move term weights to constants area/file, perhaps keep division by `dist.normed_log_densities.size` and scale term weights accordingly.

[Companion Elicit PR](https://github.com/oughtinc/elicit/pull/358)