### PR TITLE
Fix scaling for logistic fit

### DIFF
--- a/ergo/platforms/metaculus/question/continuous.py
+++ b/ergo/platforms/metaculus/question/continuous.py
@@ -322,7 +322,10 @@ class ContinuousQuestion(MetaculusQuestion):
 
         normalized_samples = self.scale.normalize_points(samples)
         _dist = dist.LogisticMixture.from_samples(
-            normalized_samples, fixed_params={"num_components": 3}, verbose=verbose
+            normalized_samples,
+            fixed_params={"num_components": 3},
+            verbose=verbose,
+            scale=Scale(0, 1),
         )
         return self.prepare_logistic_mixture(_dist)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,18 @@ def logistic_mixture():
 
 
 @pytest.fixture(scope="module")
+def smooth_logistic_mixture():
+    xscale = Scale(1, 1000000.0)
+    return LogisticMixture(
+        components=[
+            Logistic(loc=400000, s=100000, scale=xscale),
+            Logistic(loc=700000, s=50000, scale=xscale),
+        ],
+        probs=[0.8, 0.2],
+    )
+
+
+@pytest.fixture(scope="module")
 def logistic_mixture10():
     xscale = Scale(-20, 40)
     return LogisticMixture(

--- a/tests/test_metaculus.py
+++ b/tests/test_metaculus.py
@@ -142,6 +142,23 @@ def test_get_questions_question_status(metaculus):
     ).all()
 
 
+def test_submission_from_samples_smooth(metaculus_questions, smooth_logistic_mixture):
+    samples = np.array([smooth_logistic_mixture.sample() for _ in range(5000)])
+    fit_mixture = metaculus_questions.continuous_linear_open_question.get_submission_from_samples(
+        samples
+    )
+    normalized_samples_from_fit_mixture = [fit_mixture.sample() for _ in range(5000)]
+    mixture_samples = metaculus_questions.continuous_linear_open_question.denormalize_samples(
+        normalized_samples_from_fit_mixture
+    )
+    assert float(np.mean(samples)) == pytest.approx(
+        float(np.mean(mixture_samples)), rel=0.1
+    )
+    assert float(np.var(samples)) == pytest.approx(
+        float(np.var(mixture_samples)), rel=0.2
+    )
+
+
 @pytest.mark.xfail(reason="Fitting doesn't reliably work yet #219")
 def test_submission_from_samples_linear(metaculus_questions, logistic_mixture_samples):
     normalized_mixture = metaculus_questions.continuous_linear_open_question.get_submission_from_samples(


### PR DESCRIPTION
This branch fixes a problem where ergo would successfully fit a logistic mixture to a distribution but then skew it subtly.  Specifically, when called without passing a scale, the logistic mixture fitting function will use an appropriate scale based on the min and max of the data.  We were then fitting to the normalized data, but the resulting distribution had a scale that was not exactly `[0,1]`. The function that prepares the data for Metaculus submission assumes that it is given a normalized distribution, causing the submitted distribution to be shifted slightly.

This PR also includes a new test for fitting a fairly smooth distribution that the current master code fails.  Unfortunately, the existing fitting tests are still failing for other reasons.  Specifically, ergo seems to struggle to fit very spiky distributions; see #219 for some recent discussion of this.
