### PR TITLE
Fixes #408

### DIFF
--- a/ergo/platforms/metaculus/question/continuous.py
+++ b/ergo/platforms/metaculus/question/continuous.py
@@ -464,9 +464,9 @@ class ContinuousQuestion(MetaculusQuestion):
                         "For multiple predictions comparisons, only samples can be compared (plot_fitted must be False)"
                     )
                 for col in samples:
-                    df[col] = self.scale.normalize_points(samples[col])
+                    df[col] = onp.array(self.scale.normalize_points(samples[col]))
             else:
-                df["samples"] = self.scale.normalize_points(samples)
+                df["samples"] = onp.array(self.scale.normalize_points(samples))
 
         if plot_fitted:
             prediction = self.get_submission_from_samples(samples)

--- a/ergo/platforms/metaculus/question/continuous.py
+++ b/ergo/platforms/metaculus/question/continuous.py
@@ -464,8 +464,10 @@ class ContinuousQuestion(MetaculusQuestion):
                         "For multiple predictions comparisons, only samples can be compared (plot_fitted must be False)"
                     )
                 for col in samples:
+                    # use numpy array to ensure df doesn't become read-only
                     df[col] = onp.array(self.scale.normalize_points(samples[col]))
             else:
+                # use numpy array to ensure df doesn't become read-only
                 df["samples"] = onp.array(self.scale.normalize_points(samples))
 
         if plot_fitted:

--- a/tests/test_metaculus.py
+++ b/tests/test_metaculus.py
@@ -3,9 +3,6 @@ from http import HTTPStatus
 import pprint
 
 import jax.numpy as np
-import matplotlib.pyplot as plt
-import numpy as onp
-import pandas as pd
 import pytest
 import requests
 
@@ -215,32 +212,3 @@ def test_get_community_prediction_log(metaculus_questions):
 def test_sample_community_binary(metaculus_questions):
     value = metaculus_questions.binary_question.sample_community()
     assert bool(value) in (True, False)
-
-
-def test_show_prediction_with_fitted(
-    metaculus_questions, logistic_mixture_samples, monkeypatch
-):
-    monkeypatch.setattr(plt, "draw", lambda: None)
-    metaculus_questions.continuous_linear_open_question.show_prediction(
-        logistic_mixture_samples, show_commuity=True, plot_fitted=True,
-    )
-
-
-def test_show_prediction_multiple_models(
-    metaculus_questions, logistic_mixture_samples, monkeypatch
-):
-    xscale = metaculus_questions.continuous_linear_open_question.scale
-
-    samples = pd.DataFrame(
-        {
-            "logistic_samples": logistic_mixture_samples,
-            "random_samples": onp.random.random(len(logistic_mixture_samples))
-            * xscale.width
-            + xscale.low,
-        }
-    )
-
-    monkeypatch.setattr(plt, "draw", lambda: None)
-    metaculus_questions.continuous_linear_open_question.show_prediction(
-        samples, show_commuity=True,
-    )

--- a/tests/test_metaculus.py
+++ b/tests/test_metaculus.py
@@ -3,6 +3,9 @@ from http import HTTPStatus
 import pprint
 
 import jax.numpy as np
+import matplotlib.pyplot as plt
+import numpy as onp
+import pandas as pd
 import pytest
 import requests
 
@@ -212,3 +215,32 @@ def test_get_community_prediction_log(metaculus_questions):
 def test_sample_community_binary(metaculus_questions):
     value = metaculus_questions.binary_question.sample_community()
     assert bool(value) in (True, False)
+
+
+def test_show_prediction_with_fitted(
+    metaculus_questions, logistic_mixture_samples, monkeypatch
+):
+    monkeypatch.setattr(plt, "draw", lambda: None)
+    metaculus_questions.continuous_linear_open_question.show_prediction(
+        logistic_mixture_samples, show_commuity=True, plot_fitted=True,
+    )
+
+
+def test_show_prediction_multiple_models(
+    metaculus_questions, logistic_mixture_samples, monkeypatch
+):
+    xscale = metaculus_questions.continuous_linear_open_question.scale
+
+    samples = pd.DataFrame(
+        {
+            "logistic_samples": logistic_mixture_samples,
+            "random_samples": onp.random.random(len(logistic_mixture_samples))
+            * xscale.width
+            + xscale.low,
+        }
+    )
+
+    monkeypatch.setattr(plt, "draw", lambda: None)
+    metaculus_questions.continuous_linear_open_question.show_prediction(
+        samples, show_commuity=True,
+    )


### PR DESCRIPTION
Fixes a read-only error resulting from data being an immutable `jax.np` array instead of a normal numpy array.  Also adds two tests that ensure `show_prediction()` runs without errors (although it does not test the accuracy of the graphs produced).