### PR TITLE
Add '/' to Metacalculus questions url to remove redirect

### DIFF
--- a/ergo/platforms/metaculus/metaculus.py
+++ b/ergo/platforms/metaculus/metaculus.py
@@ -186,7 +186,7 @@ class Metaculus:
         :param id: Question id (can be read off from URL)
         :param name: Name to assign to this question (used in models)
         """
-        r = self.s.get(f"{self.api_url}/questions/{id}")
+        r = self.s.get(f"{self.api_url}/questions/{id}/", allow_redirects=False)
         data = r.json()
         if not data.get("possibilities"):
             print(id)

--- a/ergo/platforms/metaculus/metaculus.py
+++ b/ergo/platforms/metaculus/metaculus.py
@@ -186,7 +186,7 @@ class Metaculus:
         :param id: Question id (can be read off from URL)
         :param name: Name to assign to this question (used in models)
         """
-        r = self.s.get(f"{self.api_url}/questions/{id}/", allow_redirects=False)
+        r = self.s.get(f"{self.api_url}/questions/{id}/")
         data = r.json()
         if not data.get("possibilities"):
             print(id)


### PR DESCRIPTION
Closes #363. There wasn't a great way to test this without exposing too much from the Metaculus class, thought if you disallow redirects, as I have done, but don't add the `/`, the tests will fail.