### PR TITLE
Added a platform-independent questions-interface and integration with…

### DIFF
--- a/ergo/__init__.py
+++ b/ergo/__init__.py
@@ -4,6 +4,7 @@ import ergo.conditions
 import ergo.distributions
 import ergo.platforms
 import ergo.ppl
+import ergo.questions
 import ergo.scale
 import ergo.static
 import ergo.theme
@@ -32,6 +33,9 @@ from .distributions import (
     uniform,
 )
 from .platforms import (
+    Almanis,
+    AlmanisBinaryQuestion,
+    AlmanisQuestion,
     Foretold,
     ForetoldQuestion,
     Metaculus,

--- a/ergo/platforms/__init__.py
+++ b/ergo/platforms/__init__.py
@@ -1,3 +1,4 @@
+from .almanis import Almanis, AlmanisBinaryQuestion, AlmanisQuestion
 from .foretold import Foretold, ForetoldQuestion
 from .metaculus import Metaculus, MetaculusQuestion
 from .predictit import PredictIt, PredictItMarket, PredictItQuestion

--- a/ergo/platforms/almanis.py
+++ b/ergo/platforms/almanis.py
@@ -1,0 +1,226 @@
+from abc import abstractmethod
+import json
+from typing import Dict, List, Sequence
+
+import requests
+
+from ergo.questions import BinaryQuestion, Question
+
+
+class Almanis:
+    """
+    The main class for interacting with Almanis
+    """
+
+    question_id_request_json = json.dumps(
+        {
+            "customerID": "44d7f0b3-7e6f-4867-b00a-6816492bb510",
+            "statuses": [{"Trading": {}}, {"ClosedForTrading": {}}],
+        }
+    )
+
+    BINARY_QUESTION_KEY = "BooleanQuestionOD"
+    CONTINUOUS_QUESTION_KEY = "MultipleChoiceQuestionOD"
+
+    def __init__(self):
+        self.api_url = "https://proddysruptlabsr53tobackendapi.dysruptlabs.com/api/sharedCode/api/IntegrationLayerApi"
+        self.s = requests.Session()
+        self.question_ids = []
+
+    def refresh_question_ids(self):
+        response = self.s.post(
+            f"{self.api_url}/getQuestionIDs", data=self.question_id_request_json
+        )
+        response_json = response.json()
+        self.question_ids = [x["id"] for x in response_json]
+
+    def get_questions(self, ids: List[str]) -> Sequence["AlmanisQuestion"]:
+        request_json = json.dumps({"questionIDs": ids})
+        questions_response = self.s.post(
+            f"{self.api_url}/getQuestionsWithIDs", data=request_json
+        )
+        questions_json = questions_response.json()
+
+        prices_response = self.s.post(
+            f"{self.api_url}/getCurrentPricesForQuestionIDs", data=request_json
+        )
+        prices_json = prices_response.json()
+        prices_by_id = {p["questionID"]: p for p in prices_json}
+        questions = []
+        for question_json in questions_json:
+            if self.BINARY_QUESTION_KEY in question_json:
+                question_data = question_json[self.BINARY_QUESTION_KEY]
+                binary_question = AlmanisBinaryQuestion(
+                    self, question_data, prices_by_id[question_data["id"]]
+                )
+                questions.append(binary_question)
+            else:
+                pass  # For now, ignore the multiple choice questions
+        return questions
+
+    def get_question(self, question_id: str) -> "AlmanisQuestion":
+        return self.get_questions([question_id])[0]
+
+    def get_all_questions(self) -> Sequence["AlmanisQuestion"]:
+        self.refresh_question_ids()
+        return self.get_questions(self.question_ids)
+
+
+class AlmanisQuestion(Question):
+    """
+    A question on the Almanis platform.
+
+    :param market: Almanis market instance
+    :param data: Contract JSON retrieved from PredictIt API
+
+    :ivar str id: id of the question
+    :ivar text: name of the question
+    :ivar status: status of the question
+
+    An Almanis question looks like:
+
+    {
+        "BooleanQuestionOD": {
+            "id": "5d4350e5-7721-43f6-901d-9c4f362b992c",
+            "customerID": "44d7f0b3-7e6f-4867-b00a-6816492bb510",
+            "shortName": null,
+            "text": "By 12 Dec 2020, will the S&P 500 fall below 2,800?",
+            "description": "<p style=\"text-align:start;\"><span style=\"color: rgba(0,0,0,0.87)..."
+            "settlementDescription": "",
+            "settledAnswer": null,
+            "pricesPriorToSettlement": null,
+            "status": {
+                "Trading": {}
+            },
+            "answers": [
+                {
+                    "TrueBooleanAnswerOD": {
+                        "id": "b9fd4ad4-5575-4ce3-abb6-73f54573ed5e"
+                    }
+                },
+                {
+                    "FalseBooleanAnswerOD": {
+                        "id": "fbc99287-3f2e-408b-ae24-cfcd903722c2"
+                    }
+                }
+            ],
+            "scheduledCloseTimeForForecasting": "1607778000000",
+            "timeClosed": null,
+            "timeSettled": null,
+            "collections": [
+                "3ceddbb9-af25-41b7-8ac8-dd1162aeb1ee"
+            ],
+            "liquidityFactor": 150,
+            "socialData": {
+                "iconPictureURL": null
+            },
+            "openForTradingTime": "1604275215128",
+            "linkedQuestionIDs": []
+        }
+    }
+    """
+
+    def __init__(self, almanis: "Almanis", data: Dict, price_data: Dict):
+        self.almanis = almanis
+        self.id = data["id"]
+        self._data = data
+        self.price_data = price_data
+        self.parse_price_data()
+
+    def __getattr__(self, name: str):
+        """
+        If an attribute isn't directly on the class, check whether it's in the
+        raw contract data.
+
+        :param name:
+        :return: attribute value
+        """
+        if name not in self._data:
+            raise AttributeError(
+                f"Attribute {name} is neither directly on this class nor in the raw question data"
+            )
+        return self._data[name]
+
+    def get_text(self):
+        return self._data["text"]
+
+    @abstractmethod
+    def parse_price_data(self):
+        """
+        Parses the price data from the price_data object
+        """
+        raise NotImplementedError("This should be implemented by a subclass")
+
+    def refresh(self):
+        """
+        Refetch the prediction data from Almanis and reload the question.
+        """
+        question = self.almanis.get_question(self.id)
+        self._data = question._data
+        self.price_data = question.price_data
+        self.parse_price_data()
+
+
+class AlmanisBinaryQuestion(AlmanisQuestion, BinaryQuestion):
+    """
+    A single binary question on the Almanis platform.
+
+    A price_data object for a Binary question from Almanis API looks like:
+
+    {
+        "questionID": "3a899310-c8b2-4dd8-a17d-f4cad1307d3f",
+        "priceTime": "1604837474979",
+        "scalarMean": 0,
+        "probDist": {
+            "values": [
+                [
+                    {
+                        "TrueBooleanAnswerOD": {
+                            "id": "db513ceb-b8e2-4fcd-952e-1c0bcc1f9246"
+                        }
+                    },
+                    {
+                        "prob": 0.021141193209703504
+                    }
+                ],
+                [
+                    {
+                        "FalseBooleanAnswerOD": {
+                            "id": "0c2e08e6-a868-46ae-a643-be45990239df"
+                        }
+                    },
+                    {
+                        "prob": 0.9788588067902965
+                    }
+                ]
+            ],
+            "id": "0c8eb5c1-5344-4713-b521-38a58e308590"
+        }
+    """
+
+    def __init__(self, almanis: "Almanis", data: Dict, price_data: Dict):
+        super().__init__(almanis, data, price_data)
+
+    def __repr__(self):
+        return f'<AlmanisBinaryQuestion text="{self.text}">'
+
+    def parse_price_data(self):
+        answers = self.price_data["probDist"]["values"]
+        for answer in answers:
+            if "TrueBooleanAnswerOD" in answer[0]:
+                self.prob = answer[1]["prob"]  # See JSON structure above
+
+    def get_community_prediction(self) -> float:
+        """
+        Get the latest community probability for the binary event
+        """
+        return self.prob
+
+    def submit(self, p: float, confidence: float = 0) -> requests.Response:
+        """
+        Submit a prediction to the prediction platform
+
+        :param p: how likely is the event to happen, from 0 to 1?
+        :param confidence: Almanis points to invest in prediction
+        """
+        raise NotImplementedError("This is still TODO")

--- a/ergo/platforms/almanis.py
+++ b/ergo/platforms/almanis.py
@@ -12,12 +12,10 @@ class Almanis:
     The main class for interacting with Almanis
     """
 
-    question_id_request_json = json.dumps(
-        {
+    question_id_request_json = {
             "customerID": "44d7f0b3-7e6f-4867-b00a-6816492bb510",
             "statuses": [{"Trading": {}}, {"ClosedForTrading": {}}],
         }
-    )
 
     BINARY_QUESTION_KEY = "BooleanQuestionOD"
     CONTINUOUS_QUESTION_KEY = "MultipleChoiceQuestionOD"
@@ -29,20 +27,20 @@ class Almanis:
 
     def refresh_question_ids(self):
         response = self.s.post(
-            f"{self.api_url}/getQuestionIDs", data=self.question_id_request_json
+            f"{self.api_url}/getQuestionIDs", json=self.question_id_request_json
         )
         response_json = response.json()
         self.question_ids = [x["id"] for x in response_json]
 
     def get_questions(self, ids: List[str]) -> Sequence["AlmanisQuestion"]:
-        request_json = json.dumps({"questionIDs": ids})
+        request_json = {"questionIDs": ids}
         questions_response = self.s.post(
-            f"{self.api_url}/getQuestionsWithIDs", data=request_json
+            f"{self.api_url}/getQuestionsWithIDs", json=request_json
         )
         questions_json = questions_response.json()
 
         prices_response = self.s.post(
-            f"{self.api_url}/getCurrentPricesForQuestionIDs", data=request_json
+            f"{self.api_url}/getCurrentPricesForQuestionIDs", json=request_json
         )
         prices_json = prices_response.json()
         prices_by_id = {p["questionID"]: p for p in prices_json}

--- a/ergo/questions/__init__.py
+++ b/ergo/questions/__init__.py
@@ -1,0 +1,2 @@
+from .binary import BinaryQuestion
+from .question import Question

--- a/ergo/questions/binary.py
+++ b/ergo/questions/binary.py
@@ -26,7 +26,7 @@ class BinaryQuestion(Question):
 
     def sample_community(self) -> bool:
         """
-        Sample from the PredictIt community distribution (Bernoulli).
+        Sample from the community distribution (Bernoulli).
 
         :return: true/false
         """

--- a/ergo/questions/binary.py
+++ b/ergo/questions/binary.py
@@ -1,0 +1,33 @@
+from abc import abstractmethod
+
+import requests
+
+from ergo.distributions.base import flip
+
+from .question import Question
+
+
+class BinaryQuestion(Question):
+    @abstractmethod
+    def get_community_prediction(self) -> float:
+        """
+        Get the latest community probability for the binary event
+        """
+        raise NotImplementedError("This should be implemented by a subclass")
+
+    @abstractmethod
+    def submit(self, p: float, confidence: float = 0) -> requests.Response:
+        """
+        Submit a prediction to the prediction platform
+
+        :param p: how likely is the event to happen, from 0 to 1?
+        """
+        raise NotImplementedError("This should be implemented by a subclass")
+
+    def sample_community(self) -> bool:
+        """
+        Sample from the PredictIt community distribution (Bernoulli).
+
+        :return: true/false
+        """
+        return flip(self.get_community_prediction())

--- a/ergo/questions/question.py
+++ b/ergo/questions/question.py
@@ -1,0 +1,28 @@
+from abc import ABC, abstractmethod
+
+
+class Question(ABC):
+    """A question from a forecasting platform"""
+
+    @abstractmethod
+    def get_text(self):
+        """
+        Get the summarizing text of the question
+        """
+        raise NotImplementedError("This should be implemented by a subclass")
+
+    @abstractmethod
+    def refresh(self):
+        """
+        Retrieves the latest information on the question from the prediction platform
+        """
+        raise NotImplementedError("This should be implemented by a subclass")
+
+    @abstractmethod
+    def sample_community(self):
+        """
+        Get one sample from the distribution of the community's
+        prediction on this question
+        (sample is denormalized/on the the true scale of the question)
+        """
+        raise NotImplementedError("This should be implemented by a subclass")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,6 +219,11 @@ def predictit_markets():
     return list(ergo.PredictIt().markets)[0:3]
 
 
+@pytest.fixture(scope="module")
+def almanis():
+    return ergo.Almanis()
+
+
 def make_point_densities():
     xs = np.array(
         [

--- a/tests/test_almanis.py
+++ b/tests/test_almanis.py
@@ -1,0 +1,29 @@
+from math import isclose
+import pprint
+
+pp = pprint.PrettyPrinter(indent=4)
+
+
+def test_get_question_binary(almanis):
+    binary_question = almanis.get_question("662d7cfd-623e-4f92-b05b-124c9a061420")
+    assert binary_question.id == "662d7cfd-623e-4f92-b05b-124c9a061420"
+    assert isclose(
+        binary_question.get_community_prediction(), 1.0
+    )  # Question already resolved as "yes"
+    assert binary_question.sample_community()
+    assert (
+        binary_question.get_text()
+        == "Will the Argentine government default on its debt obligations by 12 Sep 2019?"
+    )
+    assert binary_question.status == {"Settled":{}}
+
+
+def test_refresh_question(almanis):
+    question = almanis.get_question("662d7cfd-623e-4f92-b05b-124c9a061420")
+    question.refresh()
+    assert question.id == "662d7cfd-623e-4f92-b05b-124c9a061420"
+
+
+def test_get_all_questions(almanis):
+    questions = almanis.get_all_questions()
+    assert len(questions) > 10


### PR DESCRIPTION
I've done two things in this PR:
1. I've added a questions directory and files to make a platform-independent questions interface that can be the basis for adding new platform integrations
2. I've added an integration with the Almanis prediction platform using the above interface (https://www.almanisprivate.com/almanis-app) with partial functionality. It allows you to fetch questions or a list of questions from the platform, get the current price/probability. This only works for binary questions currently.

For now I just wanted to get feedback before I go to deep on something that may not be helpful! This PR could be merged as is, and wouldn't cause any issues, but there are a few obvious things I could add:
1. Add in support for Almanis "multiple choice" questions which would map to something like Ergo's PointDensity distribution
2. Add a sample notebook using the integration
3. Add "submit" functionality so one could actually make predictions on the platform
4. Unify the other 3 platforms to use the new questions interface

If one or more of these things seems especially worthwhile to put in this PR, please let me know! If not, I'd be happy to get more fine-grained code feedback.