### PR TITLE
Allow pyproject.toml to use Python 3.7* and 3.8*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Ought <team@ought.org>"]
 
 [tool.poetry.dependencies]
-python = "^3.6.8"
+python = "^3.8.5"
 requests = "2.21.0"
 country_converter = "0.6.7"
 tqdm = "4.45.0"


### PR DESCRIPTION
Now that https://github.com/oughtinc/ergo/pull/415 is merged, can we permit Python 3.7* and 3.8* on install? This will avoid the `ERROR: Package 'ergo' requires a different Python: 3.8.6 not in '>=3.6.8,<3.7.0'` install error.

*WARNING: This PR has not been tested*